### PR TITLE
refactor: 코드 가독성을 증진시킨다

### DIFF
--- a/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
@@ -10,29 +10,6 @@ interface Props {
   googleMap: google.maps.Map;
 }
 
-const CarFfeineMapListener = ({ googleMap }: Props) => {
-  const { updateStations } = useUpdateStations();
-
-  useEffect(() => {
-    googleMap.addListener('dragend', () => {
-      console.log('dragend');
-      updateStations(googleMap);
-    });
-
-    googleMap.addListener('zoom_changed', () => {
-      console.log('zoom_changed');
-      updateStations(googleMap);
-    });
-
-    const initMarkersEvent = googleMap.addListener('bounds_changed', () => {
-      updateStations(googleMap);
-      google.maps.event.removeListener(initMarkersEvent);
-    });
-  }, []);
-
-  return <></>;
-};
-
 const CarFfeineMap = () => {
   const ref = useRef<HTMLDivElement>(null);
   const [googleMap, setGoogleMap] = useState<google.maps.Map>();
@@ -65,6 +42,29 @@ const CarFfeineMap = () => {
       )}
     </>
   );
+};
+
+const CarFfeineMapListener = ({ googleMap }: Props) => {
+  const { updateStations } = useUpdateStations();
+
+  useEffect(() => {
+    googleMap.addListener('dragend', () => {
+      console.log('dragend');
+      updateStations(googleMap);
+    });
+
+    googleMap.addListener('zoom_changed', () => {
+      console.log('zoom_changed');
+      updateStations(googleMap);
+    });
+
+    const initMarkersEvent = googleMap.addListener('bounds_changed', () => {
+      updateStations(googleMap);
+      google.maps.event.removeListener(initMarkersEvent);
+    });
+  }, []);
+
+  return <></>;
 };
 
 export default CarFfeineMap;

--- a/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
@@ -8,10 +8,10 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
 
 interface Props {
-  map: google.maps.Map;
+  googleMap: google.maps.Map;
 }
 
-const CarFfeinMapListener = ({ map }: Props) => {
+const CarFfeinMapListener = ({ googleMap }: Props) => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(['stations'], {
@@ -22,18 +22,18 @@ const CarFfeinMapListener = ({ map }: Props) => {
   });
 
   useEffect(() => {
-    map.addListener('dragend', () => {
+    googleMap.addListener('dragend', () => {
       console.log('dragend');
-      mutate(map);
+      mutate(googleMap);
     });
 
-    map.addListener('zoom_changed', () => {
+    googleMap.addListener('zoom_changed', () => {
       console.log('zoom_changed');
-      mutate(map);
+      mutate(googleMap);
     });
 
-    const initMarkersEvent = map.addListener('bounds_changed', () => {
-      mutate(map);
+    const initMarkersEvent = googleMap.addListener('bounds_changed', () => {
+      mutate(googleMap);
       google.maps.event.removeListener(initMarkersEvent);
     });
   }, []);
@@ -66,9 +66,9 @@ const CarFfeineMap = () => {
       <div ref={ref} id="map" style={{ minHeight: '100vh' }} />
       {isClientReady && (
         <>
-          <CarFfeinMapListener map={googleMap} />
-          <StationMarkersContainer map={googleMap} />
-          <UserMarker map={googleMap} position={position} />
+          <CarFfeinMapListener googleMap={googleMap} />
+          <StationMarkersContainer googleMap={googleMap} />
+          <UserMarker googleMap={googleMap} position={position} />
         </>
       )}
     </>

--- a/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
@@ -4,36 +4,28 @@ import { INITIAL_ZOOM_SIZE } from '../../../constants';
 import { useCurrentPosition } from '../../../hooks/useCurrentPosition';
 import UserMarker from '../marker/UserMarker';
 import StationMarkersContainer from '../marker/StationMarkersContainer';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchStation } from '../../../hooks/useStations';
+import { useUpdateStations } from '../../../hooks/useUpdateStations';
 
 interface Props {
   googleMap: google.maps.Map;
 }
 
 const CarFfeineMapListener = ({ googleMap }: Props) => {
-  const queryClient = useQueryClient();
-
-  const { mutate } = useMutation(['stations'], {
-    mutationFn: fetchStation,
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['stations'] });
-    },
-  });
+  const { updateStations } = useUpdateStations();
 
   useEffect(() => {
     googleMap.addListener('dragend', () => {
       console.log('dragend');
-      mutate(googleMap);
+      updateStations(googleMap);
     });
 
     googleMap.addListener('zoom_changed', () => {
       console.log('zoom_changed');
-      mutate(googleMap);
+      updateStations(googleMap);
     });
 
     const initMarkersEvent = googleMap.addListener('bounds_changed', () => {
-      mutate(googleMap);
+      updateStations(googleMap);
       google.maps.event.removeListener(initMarkersEvent);
     });
   }, []);

--- a/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
@@ -6,12 +6,9 @@ import UserMarker from '../marker/UserMarker';
 import StationMarkersContainer from '../marker/StationMarkersContainer';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
+import type { googleMap } from '../../../types';
 
-interface Props {
-  googleMap: google.maps.Map;
-}
-
-const CarFfeinMapListener = ({ googleMap }: Props) => {
+const CarFfeinMapListener = ({ googleMap }: googleMap) => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(['stations'], {

--- a/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
@@ -6,9 +6,12 @@ import UserMarker from '../marker/UserMarker';
 import StationMarkersContainer from '../marker/StationMarkersContainer';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
-import type { googleMap } from '../../../types';
 
-const CarFfeineMapListener = ({ googleMap }: googleMap) => {
+interface Props {
+  googleMap: google.maps.Map;
+}
+
+const CarFfeineMapListener = ({ googleMap }: Props) => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(['stations'], {

--- a/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/googleMaps/map/CarFfeineMap.tsx
@@ -8,7 +8,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
 import type { googleMap } from '../../../types';
 
-const CarFfeinMapListener = ({ googleMap }: googleMap) => {
+const CarFfeineMapListener = ({ googleMap }: googleMap) => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(['stations'], {
@@ -63,7 +63,7 @@ const CarFfeineMap = () => {
       <div ref={ref} id="map" style={{ minHeight: '100vh' }} />
       {isClientReady && (
         <>
-          <CarFfeinMapListener googleMap={googleMap} />
+          <CarFfeineMapListener googleMap={googleMap} />
           <StationMarkersContainer googleMap={googleMap} />
           <UserMarker googleMap={googleMap} position={position} />
         </>

--- a/frontend/src/components/googleMaps/marker/StationMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarker.tsx
@@ -6,13 +6,13 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
 
 interface Props {
-  map: google.maps.Map;
+  googleMap: google.maps.Map;
   station: Station;
   briefStationInfoRoot: Root;
   infoWindow: google.maps.InfoWindow;
 }
 
-const StationMarker = ({ map, station, briefStationInfoRoot, infoWindow }: Props) => {
+const StationMarker = ({ googleMap, station, briefStationInfoRoot, infoWindow }: Props) => {
   const { latitude, longitude, stationName } = station;
 
   const queryClient = useQueryClient();
@@ -27,19 +27,19 @@ const StationMarker = ({ map, station, briefStationInfoRoot, infoWindow }: Props
   useEffect(() => {
     const markerInstance = new google.maps.Marker({
       position: { lat: latitude, lng: longitude },
-      map: map,
+      map: googleMap,
       title: stationName,
     });
 
     markerInstance.addListener('click', () => {
       infoWindow.open({
         anchor: markerInstance,
-        map,
+        map: googleMap,
       });
 
       briefStationInfoRoot.render(<BriefStationInfo station={station} />);
-      map.panTo(markerInstance.getPosition());
-      mutate(map);
+      googleMap.panTo(markerInstance.getPosition());
+      mutate(googleMap);
     });
 
     return () => {

--- a/frontend/src/components/googleMaps/marker/StationMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarker.tsx
@@ -1,12 +1,12 @@
 import { useEffect } from 'react';
 import type { Root } from 'react-dom/client';
-import type { Station } from '../../../types';
+
 import BriefStationInfo from '../../BriefStationInfo';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
+import type { Station, googleMap } from '../../../types';
 
-interface Props {
-  googleMap: google.maps.Map;
+interface Props extends googleMap {
   station: Station;
   briefStationInfoRoot: Root;
   infoWindow: google.maps.InfoWindow;

--- a/frontend/src/components/googleMaps/marker/StationMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarker.tsx
@@ -4,9 +4,10 @@ import type { Root } from 'react-dom/client';
 import BriefStationInfo from '../../BriefStationInfo';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { fetchStation } from '../../../hooks/useStations';
-import type { Station, googleMap } from '../../../types';
+import type { Station } from '../../../types';
 
-interface Props extends googleMap {
+interface Props {
+  googleMap: google.maps.Map;
   station: Station;
   briefStationInfoRoot: Root;
   infoWindow: google.maps.InfoWindow;

--- a/frontend/src/components/googleMaps/marker/StationMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarker.tsx
@@ -2,8 +2,7 @@ import { useEffect } from 'react';
 import type { Root } from 'react-dom/client';
 
 import BriefStationInfo from '../../BriefStationInfo';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { fetchStation } from '../../../hooks/useStations';
+import { useUpdateStations } from '../../../hooks/useUpdateStations';
 import type { Station } from '../../../types';
 
 interface Props {
@@ -16,14 +15,7 @@ interface Props {
 const StationMarker = ({ googleMap, station, briefStationInfoRoot, infoWindow }: Props) => {
   const { latitude, longitude, stationName } = station;
 
-  const queryClient = useQueryClient();
-
-  const { mutate } = useMutation(['stations'], {
-    mutationFn: fetchStation,
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: ['stations'] });
-    },
-  }); // TODO: 다른 곳에서도 코드 그대로 사용 중이므로 모듈화 필요
+  const { updateStations } = useUpdateStations();
 
   useEffect(() => {
     const markerInstance = new google.maps.Marker({
@@ -40,7 +32,7 @@ const StationMarker = ({ googleMap, station, briefStationInfoRoot, infoWindow }:
 
       briefStationInfoRoot.render(<BriefStationInfo station={station} />);
       googleMap.panTo(markerInstance.getPosition());
-      mutate(googleMap);
+      updateStations(googleMap);
     });
 
     return () => {

--- a/frontend/src/components/googleMaps/marker/StationMarkersContainer.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarkersContainer.tsx
@@ -6,11 +6,11 @@ import StationMarker from './StationMarker';
 import { useStations } from '../../../hooks/useStations';
 
 interface Props {
-  map: google.maps.Map;
+  googleMap: google.maps.Map;
 }
 
-const StationMarkersContainer = ({ map }: Props) => {
-  const { ...queryInfo } = useStations(map);
+const StationMarkersContainer = ({ googleMap }: Props) => {
+  const { ...queryInfo } = useStations(googleMap);
   const stations = queryInfo.data;
 
   const [briefStationInfoRoot, setBriefStationInfoRoot] = useState<Root>();
@@ -36,7 +36,7 @@ const StationMarkersContainer = ({ map }: Props) => {
       {stations.map((station) => (
         <StationMarker
           key={station.stationId}
-          map={map}
+          googleMap={googleMap}
           station={station}
           briefStationInfoRoot={briefStationInfoRoot}
           infoWindow={infoWindow}

--- a/frontend/src/components/googleMaps/marker/StationMarkersContainer.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarkersContainer.tsx
@@ -4,9 +4,12 @@ import type { Root } from 'react-dom/client';
 
 import StationMarker from './StationMarker';
 import { useStations } from '../../../hooks/useStations';
-import type { googleMap } from '../../../types';
 
-const StationMarkersContainer = ({ googleMap }: googleMap) => {
+interface Props {
+  googleMap: google.maps.Map;
+}
+
+const StationMarkersContainer = ({ googleMap }: Props) => {
   const { ...queryInfo } = useStations(googleMap);
   const stations = queryInfo.data;
 

--- a/frontend/src/components/googleMaps/marker/StationMarkersContainer.tsx
+++ b/frontend/src/components/googleMaps/marker/StationMarkersContainer.tsx
@@ -1,15 +1,12 @@
 import { useEffect, useState } from 'react';
-import type { Root } from 'react-dom/client';
 import { createRoot } from 'react-dom/client';
+import type { Root } from 'react-dom/client';
 
 import StationMarker from './StationMarker';
 import { useStations } from '../../../hooks/useStations';
+import type { googleMap } from '../../../types';
 
-interface Props {
-  googleMap: google.maps.Map;
-}
-
-const StationMarkersContainer = ({ googleMap }: Props) => {
+const StationMarkersContainer = ({ googleMap }: googleMap) => {
   const { ...queryInfo } = useStations(googleMap);
   const stations = queryInfo.data;
 

--- a/frontend/src/components/googleMaps/marker/UserMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/UserMarker.tsx
@@ -1,7 +1,8 @@
 import { useEffect } from 'react';
 
-interface Props {
-  googleMap: google.maps.Map;
+import type { googleMap } from '../../../types';
+
+interface Props extends googleMap {
   position: google.maps.LatLngLiteral;
 }
 

--- a/frontend/src/components/googleMaps/marker/UserMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/UserMarker.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
 
-import type { googleMap } from '../../../types';
-
-interface Props extends googleMap {
+interface Props {
+  googleMap: google.maps.Map;
   position: google.maps.LatLngLiteral;
 }
 

--- a/frontend/src/components/googleMaps/marker/UserMarker.tsx
+++ b/frontend/src/components/googleMaps/marker/UserMarker.tsx
@@ -1,17 +1,17 @@
 import { useEffect } from 'react';
 
 interface Props {
-  map: google.maps.Map;
+  googleMap: google.maps.Map;
   position: google.maps.LatLngLiteral;
 }
 
-const UserMarker = ({ map, position }: Props) => {
+const UserMarker = ({ googleMap, position }: Props) => {
   const { lat, lng } = position;
 
   useEffect(() => {
     const newMarker = new google.maps.Marker({
       position: { lat, lng },
-      map: map,
+      map: googleMap,
     });
 
     newMarker.addListener('click', () => console.log(`현재 위치: ${lat} ${lng}`));

--- a/frontend/src/hooks/useStations.ts
+++ b/frontend/src/hooks/useStations.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import type { Station } from '../types';
 import { getDisplayPosition } from '../utils/google-maps';
+import type { Station } from '../types';
 
 export const fetchStation = async (map: google.maps.Map) => {
   const stationQuery = getDisplayPosition(map);

--- a/frontend/src/hooks/useUpdateStations.ts
+++ b/frontend/src/hooks/useUpdateStations.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { fetchStation } from './useStations';
+
+export const useUpdateStations = () => {
+  const queryClient = useQueryClient();
+
+  const { mutate } = useMutation(['stations'], {
+    mutationFn: fetchStation,
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['stations'] });
+    },
+  });
+
+  const updateStations = (googleMap: google.maps.Map) => {
+    mutate(googleMap);
+  };
+
+  return { updateStations };
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,7 @@
+export interface googleMap {
+  googleMap: google.maps.Map;
+}
+
 export interface Station {
   stationId: number;
   stationName: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,7 +1,3 @@
-export interface googleMap {
-  googleMap: google.maps.Map;
-}
-
 interface Coordinates {
   latitude: number;
   longitude: number;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -2,7 +2,12 @@ export interface googleMap {
   googleMap: google.maps.Map;
 }
 
-export interface Station {
+interface Coordinates {
+  latitude: number;
+  longitude: number;
+}
+
+export interface Station extends Coordinates {
   stationId: number;
   stationName: string;
   companyName: string;
@@ -14,16 +19,12 @@ export interface Station {
   isParkingFree: boolean;
   operatingTime: string;
   detailLocation: string;
-  latitude: number;
-  longitude: number;
   isPrivate: boolean;
   totalCount: number;
   availableCount: number;
 }
 
-export interface DisplayPosition {
-  longitude: number;
-  latitude: number;
+export interface DisplayPosition extends Coordinates {
   longitudeDelta: number;
   latitudeDelta: number;
 }

--- a/frontend/src/utils/google-maps/index.ts
+++ b/frontend/src/utils/google-maps/index.ts
@@ -1,8 +1,6 @@
-import type { DisplayPosition } from '../../types';
-
 export const getDisplayPosition = (map: google.maps.Map) => {
-  const center = map.getCenter() as google.maps.LatLng;
-  const bounds = map.getBounds() as google.maps.LatLngBounds;
+  const center = map.getCenter();
+  const bounds = map.getBounds();
 
   const longitudeDelta = bounds
     ? (bounds.getNorthEast().lng() - bounds.getSouthWest().lng()) / 2
@@ -18,5 +16,5 @@ export const getDisplayPosition = (map: google.maps.Map) => {
     latitude,
     longitudeDelta,
     latitudeDelta,
-  } as DisplayPosition;
+  };
 };


### PR DESCRIPTION
## 📄 Summary
> 포괄적인 파라미터명을 좀 더 명확히 한다.
타입 중복을 없앤다.
 CarFfeineMap 컴포넌트 아래에 CarFfeineMapListener 배치한다.
 useMutation(['stations']) 커스텀 훅으로 분리한다.

## 🙋🏻 More
> 실제 소요 시간: 50분
