### PR TITLE
feat: 테스트 격리를 위한 기능을 만든다

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    testImplementation 'io.rest-assured:rest-assured:4.4.0'
 
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
 }

--- a/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeStation.java
+++ b/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeStation.java
@@ -14,6 +14,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Getter
 @Builder
@@ -63,5 +64,65 @@ public class ChargeStation {
         return (int) chargers.stream()
                 .filter(Charger::isAvailable)
                 .count();
+    }
+
+    public boolean isUpdated(final ChargeStation station) {
+        if (!stationName.equals(station.stationName)) {
+            return true;
+        }
+
+        if (!companyName.equals(station.companyName)) {
+            return true;
+        }
+
+        if (!isParkingFree.equals(station.isParkingFree)) {
+            return true;
+        }
+
+        if (!operatingTime.equals(station.operatingTime)) {
+            return true;
+        }
+
+        if (!detailLocation.equals(station.detailLocation)) {
+            return true;
+        }
+
+        if (!latitude.getValue().equals(station.getLatitude().getValue())) {
+            return true;
+        }
+
+        if (!longitude.getValue().equals(station.longitude.getValue())) {
+            return true;
+        }
+
+        if (!isPrivate.equals(station.isPrivate)) {
+            return true;
+        }
+
+        if (!contact.equals(station.contact)) {
+            return true;
+        }
+
+        if (!stationState.equals(station.stationState)) {
+            return true;
+        }
+
+        if (!privateReason.equals(station.privateReason)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ChargeStation that)) return false;
+        return Objects.equals(stationId, that.stationId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(stationId);
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeStationRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeStationRepository.java
@@ -1,6 +1,7 @@
 package com.carffeine.carffeine.domain.chargerStation.chargeStation;
 
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 import java.util.List;
@@ -14,4 +15,7 @@ public interface ChargeStationRepository extends Repository<ChargeStation, Long>
     List<ChargeStation> findAllByLatitudeBetweenAndLongitudeBetween(Latitude minLatitude, Latitude maxLatitude, Longitude minLongitude, Longitude maxLongitude);
 
     Optional<ChargeStation> findChargeStationByStationId(String stationId);
+
+    @Query("SELECT DISTINCT c FROM ChargeStation c JOIN FETCH c.chargers")
+    List<ChargeStation> findAll();
 }

--- a/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeUpdateJdbc.java
+++ b/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeUpdateJdbc.java
@@ -1,0 +1,114 @@
+package com.carffeine.carffeine.domain.chargerStation.chargeStation;
+
+import com.carffeine.carffeine.domain.chargerStation.charger.Charger;
+import com.carffeine.carffeine.domain.chargerStation.charger.ChargerStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public class ChargeUpdateJdbc {
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+
+    public ChargeUpdateJdbc(JdbcTemplate jdbcTemplate) {
+        this.namedParameterJdbcTemplate = new NamedParameterJdbcTemplate(jdbcTemplate);
+    }
+
+    public void saveAllStationsBatch(List<ChargeStation> chargeStations) {
+        String sql = "INSERT INTO ChargeStation (stationId, stationName, companyName, isParkingFree, operatingTime, detailLocation, latitude, longitude, isPrivate, contact, stationState, privateReason)" +
+                " VALUES (:stationId, :stationName, :companyName, :isParkingFree, :operatingTime, :detailLocation, :latitude, :longitude, :isPrivate, :contact, :stationState, :privateReason)";
+
+        namedParameterJdbcTemplate.batchUpdate(sql, chargeStationSqlParameterSource(chargeStations));
+    }
+
+    private MapSqlParameterSource[] chargeStationSqlParameterSource(List<ChargeStation> chargeStations) {
+        return chargeStations.stream()
+                .map(this::changeToSqlParameterSource)
+                .toArray(MapSqlParameterSource[]::new);
+    }
+
+    private MapSqlParameterSource changeToSqlParameterSource(ChargeStation chargeStation) {
+        return new MapSqlParameterSource()
+                .addValue("stationId", chargeStation.getStationId())
+                .addValue("stationName", chargeStation.getStationName())
+                .addValue("companyName", chargeStation.getCompanyName())
+                .addValue("isParkingFree", chargeStation.getIsParkingFree())
+                .addValue("operatingTime", chargeStation.getOperatingTime())
+                .addValue("detailLocation", chargeStation.getDetailLocation())
+                .addValue("latitude", chargeStation.getLatitude().getValue())
+                .addValue("longitude", chargeStation.getLongitude().getValue())
+                .addValue("isPrivate", chargeStation.getIsPrivate())
+                .addValue("contact", chargeStation.getContact())
+                .addValue("stationState", chargeStation.getStationState())
+                .addValue("privateReason", chargeStation.getPrivateReason());
+    }
+
+    public void updateAllStationsBatch(List<ChargeStation> chargeStations) {
+        String sql = "UPDATE ChargeStation " +
+                "SET contact = :contact, companyName = :companyName, detailLocation = :detailLocation, isParkingFree = :isParkingFree, isPrivate = :isPrivate, latitude = :latitude, longitude = :longitude, operatingTime = :operatingTime, privateReason = :privateReason, stationName = :stationName, stationState =:stationState " +
+                "WHERE stationId = :stationId";
+
+
+        namedParameterJdbcTemplate.batchUpdate(sql, chargeStationSqlParameterSource(chargeStations));
+    }
+
+    public void saveAllChargersBatch(List<Charger> chargeStations) {
+        String chargerStatusSql = "INSERT INTO ChargerStatus (charger_id, station_id, chargerState, latestUpdateTime)" +
+                " VALUES (:chargerId, :stationId, :chargerState, :latestUpdateTime)";
+
+        List<ChargerStatus> collect = chargeStations.stream()
+                .map(Charger::getChargerStatus)
+                .toList();
+
+        namedParameterJdbcTemplate.batchUpdate(chargerStatusSql, chargerStatusSqlParameterSource(collect));
+
+        String sql = "INSERT INTO Charger (station_id, charger_id, type, address, price, capacity, method, fk_station_id, fk_charger_id)" +
+                " VALUES (:stationId, :chargerId, :type, :address, :price, :capacity, :method, :fkStationId, :fkChargerId)";
+
+        namedParameterJdbcTemplate.batchUpdate(sql, chargerSqlParameterSource(chargeStations));
+    }
+
+    public void updateAllChargersBatch(List<Charger> chargeStations) {
+        String sql = "UPDATE Charger SET type = :type, address = :address, price = :price, capacity = :capacity, method = :method " +
+                "WHERE station_id = :stationId AND charger_id = :chargerId";
+
+        namedParameterJdbcTemplate.batchUpdate(sql, chargerSqlParameterSource(chargeStations));
+    }
+
+    private MapSqlParameterSource[] chargerSqlParameterSource(List<Charger> chargers) {
+        return chargers.stream()
+                .map(this::changeToChargerSqlParameterSource)
+                .toArray(MapSqlParameterSource[]::new);
+    }
+
+    private MapSqlParameterSource[] chargerStatusSqlParameterSource(List<ChargerStatus> chargerStatuses) {
+        return chargerStatuses.stream()
+                .map(this::changeToChargerStatusSqlParameterSource)
+                .toArray(MapSqlParameterSource[]::new);
+    }
+
+    private MapSqlParameterSource changeToChargerSqlParameterSource(Charger charger) {
+        return new MapSqlParameterSource()
+                .addValue("stationId", charger.getStationId())
+                .addValue("chargerId", charger.getChargerId())
+                .addValue("type", charger.getType())
+                .addValue("address", charger.getAddress())
+                .addValue("price", charger.getPrice())
+                .addValue("capacity", charger.getCapacity())
+                .addValue("method", charger.getMethod())
+                .addValue("fkStationId", charger.getStationId())
+                .addValue("fkChargerId", charger.getChargerId());
+    }
+
+    private MapSqlParameterSource changeToChargerStatusSqlParameterSource(ChargerStatus chargerStatus) {
+        return new MapSqlParameterSource()
+                .addValue("chargerId", chargerStatus.getChargerId())
+                .addValue("stationId", chargerStatus.getStationId())
+                .addValue("chargerState", chargerStatus.getChargerState().getValue())
+                .addValue("latestUpdateTime", chargerStatus.getLatestUpdateTime());
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/charger/Charger.java
+++ b/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/charger/Charger.java
@@ -9,8 +9,10 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.ConstraintMode;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
+import javax.persistence.ForeignKey;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.JoinColumn;
@@ -49,10 +51,10 @@ public class Charger {
     private String method;
 
     @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    @JoinColumns({
+    @JoinColumns(value = {
             @JoinColumn(name = "fk_station_id"),
             @JoinColumn(name = "fk_charger_id")
-    })
+    }, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
     private ChargerStatus chargerStatus;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -61,5 +63,25 @@ public class Charger {
 
     public boolean isAvailable() {
         return chargerStatus.isAvailable();
+    }
+
+    public boolean isUpdated(final Charger charger) {
+        if (!this.type.equals(charger.type)) {
+            return true;
+        }
+
+        if (!this.address.equals(charger.address)) {
+            return true;
+        }
+
+        if (this.capacity != null && this.capacity.compareTo(charger.capacity) != 0) {
+            return true;
+        }
+
+        if (!this.method.equals(charger.method)) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/charger/ChargerState.java
+++ b/backend/src/main/java/com/carffeine/carffeine/domain/chargerStation/charger/ChargerState.java
@@ -27,4 +27,8 @@ public enum ChargerState {
     public boolean isStandBy() {
         return this == STANDBY;
     }
+
+    public int getValue() {
+        return value;
+    }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/service/ChargerStationUpdateService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/service/ChargerStationUpdateService.java
@@ -1,0 +1,113 @@
+package com.carffeine.carffeine.service;
+
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeStation;
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeStationRepository;
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeUpdateJdbc;
+import com.carffeine.carffeine.domain.chargerStation.charger.Charger;
+import com.carffeine.carffeine.service.chargerStation.UpdateScrapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class ChargerStationUpdateService {
+
+    private final UpdateScrapper updateScrapper;
+    private final ChargeStationRepository chargeStationRepository;
+    private final ChargeUpdateJdbc chargeUpdateJdbc;
+
+    @Transactional
+    public void updateStations() {
+        List<ChargeStation> chargeStations = chargeStationRepository.findAll();
+        List<ChargeStation> updatedStations = updateScrapper.updateData();
+
+        Map<String, ChargeStation> savedStationsByStationId = chargeStations.stream()
+                .collect(Collectors.toMap(ChargeStation::getStationId, it -> it));
+
+        List<ChargeStation> toSaveStations = new ArrayList<>();
+        List<ChargeStation> toUpdateStations = new ArrayList<>();
+        List<Charger> toSaveChargers = new ArrayList<>();
+        List<Charger> toUpdateChargers = new ArrayList<>();
+
+        for (ChargeStation updateStation : updatedStations) {
+            if (isNewStation(savedStationsByStationId, updateStation)) {
+                toSaveStations.add(updateStation);
+                continue;
+            }
+
+            ChargeStation savedStation = savedStationsByStationId.get(updateStation.getStationId());
+            if (savedStation.isUpdated(updateStation)) {
+                toUpdateStations.add(updateStation);
+            }
+
+            updateChargers(updateStation, savedStation, toSaveChargers, toUpdateChargers);
+        }
+
+        saveAllStations(toSaveStations);
+        updateAllStations(toUpdateStations);
+
+        saveAllChargers(toSaveChargers);
+        updateAllChargers(toUpdateChargers);
+    }
+
+    private boolean isNewStation(Map<String, ChargeStation> savedStationsByStationId, ChargeStation newStationFromScrap) {
+        return !savedStationsByStationId.containsKey(newStationFromScrap.getStationId());
+    }
+
+    private void updateChargers(
+            ChargeStation updatedStations,
+            ChargeStation savedStations,
+            List<Charger> toSaveChargers,
+            List<Charger> toUpdateChargers
+    ) {
+        Map<String, Charger> savedChargerByChargerId = savedStations.getChargers().stream()
+                .collect(Collectors.toMap(Charger::getChargerId, it -> it));
+
+        for (Charger updatedCharger : updatedStations.getChargers()) {
+            if (isNewCharger(savedChargerByChargerId, updatedCharger)) {
+                toSaveChargers.add(updatedCharger);
+                continue;
+            }
+
+            Charger savedCharger = savedChargerByChargerId.get(updatedCharger.getChargerId());
+            if (savedCharger.isUpdated(updatedCharger)) {
+                toUpdateChargers.add(updatedCharger);
+            }
+        }
+    }
+
+    private boolean isNewCharger(Map<String, Charger> savedChargerByChargerId, Charger updatedCharger) {
+        return !savedChargerByChargerId.containsKey(updatedCharger.getChargerId());
+    }
+
+
+    private void saveAllStations(List<ChargeStation> toSaveStations) {
+        if (!toSaveStations.isEmpty()) {
+            chargeUpdateJdbc.saveAllStationsBatch(toSaveStations);
+        }
+    }
+
+    private void updateAllStations(List<ChargeStation> toUpdateStations) {
+        if (!toUpdateStations.isEmpty()) {
+            chargeUpdateJdbc.updateAllStationsBatch(toUpdateStations);
+        }
+    }
+
+    private void saveAllChargers(List<Charger> toSaveChargers) {
+        if (!toSaveChargers.isEmpty()) {
+            chargeUpdateJdbc.saveAllChargersBatch(toSaveChargers);
+        }
+    }
+
+    private void updateAllChargers(List<Charger> toUpdateChargers) {
+        if (!toUpdateChargers.isEmpty()) {
+            chargeUpdateJdbc.updateAllChargersBatch(toUpdateChargers);
+        }
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/service/chargerStation/UpdateScrapper.java
+++ b/backend/src/main/java/com/carffeine/carffeine/service/chargerStation/UpdateScrapper.java
@@ -1,0 +1,66 @@
+package com.carffeine.carffeine.service.chargerStation;
+
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeStation;
+import com.carffeine.carffeine.domain.chargerStation.charger.Charger;
+import com.carffeine.carffeine.service.chargerStation.dto.ChargeStationRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@RequiredArgsConstructor
+@Service
+public class UpdateScrapper {
+    private static final String REQUEST_URL = "/getChargerInfo";
+    private static final int ROW_SIZE = 9999;
+    private static final String DATA_TYPE = "JSON";
+    private final RestTemplate restTemplate;
+    private static final String SERVICE_KEY = "";
+
+    public List<ChargeStation> updateData() {
+        URI uri = UriComponentsBuilder.fromUriString("https://apis.data.go.kr/B552584/EvCharger")
+                .path(REQUEST_URL)
+                .queryParam("serviceKey", SERVICE_KEY)
+                .queryParam("pageNo", 1)
+                .queryParam("numOfRows", ROW_SIZE)
+                .queryParam("dataType", DATA_TYPE)
+                .build()
+                .toUri();
+
+        ChargeStationRequest chargeStationRequest = restTemplate.getForObject(uri, ChargeStationRequest.class);
+        List<ChargeStation> chargeStations = Objects.requireNonNull(chargeStationRequest)
+                .items()
+                .toDomains();
+
+        Map<String, List<Charger>> chargersByStationId = new HashMap<>();
+        Map<String, ChargeStation> chargeStationByStationId = new HashMap<>();
+
+        for (ChargeStation chargeStation : chargeStations) {
+            String chargeStationId = chargeStation.getStationId();
+            chargeStationByStationId.put(chargeStationId, chargeStation);
+
+            List<Charger> chargers = chargersByStationId.getOrDefault(chargeStationId, new ArrayList<>());
+
+            chargers.add(chargeStation.getChargers().get(0));
+            chargersByStationId.put(chargeStationId, chargers);
+        }
+
+        List<ChargeStation> chargeStationsToSave = new ArrayList<>();
+
+        for (String stationId : chargersByStationId.keySet()) {
+            ChargeStation chargeStation = chargeStationByStationId.get(stationId);
+            chargeStation.setChargers(chargersByStationId.get(stationId));
+            chargeStationsToSave.add(chargeStation);
+        }
+
+        return chargeStationsToSave;
+    }
+
+}

--- a/backend/src/test/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeStationTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/domain/chargerStation/chargeStation/ChargeStationTest.java
@@ -29,4 +29,30 @@ class ChargeStationTest {
 
         assertThat(actual).isEqualTo(1);
     }
+
+    @Test
+    void 충전소가_업데이트_된다면_true를_반환한다() {
+        // given
+        ChargeStation station = ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개_완속;
+        ChargeStation updatedStation = ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개_이름_변경됨;
+
+        // when
+        boolean isUpdated = station.isUpdated(updatedStation);
+
+        // then
+        assertThat(isUpdated).isTrue();
+    }
+
+    @Test
+    void 충전소가_업데이트가_안된다면_false를_반환한다() {
+        // given
+        ChargeStation station = ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개_완속;
+        ChargeStation updatedStation = ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개_완속;
+
+        // when
+        boolean isUpdated = station.isUpdated(updatedStation);
+
+        // then
+        assertThat(isUpdated).isFalse();
+    }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/domain/chargerStation/charger/ChargerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/domain/chargerStation/charger/ChargerTest.java
@@ -1,6 +1,5 @@
 package com.carffeine.carffeine.domain.chargerStation.charger;
 
-import com.carffeine.carffeine.domain.chargerStation.charger.Charger;
 import com.carffeine.carffeine.fixture.chargerStation.ChargerFixture;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -19,5 +18,31 @@ class ChargerTest {
         boolean expect = charger.isAvailable();
 
         assertThat(expect).isTrue();
+    }
+
+    @Test
+    void 충전기가_업데이트_된다면_true를_반환한다() {
+        // given
+        Charger charger = ChargerFixture.선릉역_충전기_2번_사용_중;
+        Charger updateCharger = ChargerFixture.선릉역_충전기_2번_변경됨;
+
+        // when
+        boolean isUpdated = charger.isUpdated(updateCharger);
+
+        // then
+        assertThat(isUpdated).isTrue();
+    }
+
+    @Test
+    void 충전기가_업데이트가_안된다면_false를_반환한다() {
+        // given
+        Charger charger = ChargerFixture.선릉역_충전기_2번_사용_중;
+        Charger updateCharger = ChargerFixture.선릉역_충전기_2번_사용_중;
+
+        // when
+        boolean isUpdated = charger.isUpdated(updateCharger);
+
+        // then
+        assertThat(isUpdated).isFalse();
     }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/fake/chargerStation/FakeChargeStationRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/fake/chargerStation/FakeChargeStationRepository.java
@@ -34,4 +34,10 @@ public class FakeChargeStationRepository implements ChargeStationRepository {
                 .filter(it -> it.getStationId().equals(stationId))
                 .findAny();
     }
+
+    @Override
+    public List<ChargeStation> findAll() {
+        return map.values().stream()
+                .toList();
+    }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/fixture/chargerStation/ChargeStationFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/fixture/chargerStation/ChargeStationFixture.java
@@ -30,4 +30,64 @@ public class ChargeStationFixture {
             )
             .build();
 
+    public static final ChargeStation 선릉역_충전소_충전기_2개_사용가능_1개_완속 = ChargeStation.builder()
+            .stationId("ME101010")
+            .stationName("선릉역 충전소")
+            .companyName("볼튼")
+            .isParkingFree(true)
+            .operatingTime("24시간 이용가능")
+            .detailLocation("2층")
+            .latitude(Latitude.from("38.3994933"))
+            .longitude(Longitude.from("128.3994933"))
+            .isPrivate(false)
+            .contact("02-0202-0202")
+            .stationState("yyyy-mm-dd일부터 충전소 공사합니다.")
+            .privateReason("이용 제한 사유 없습니다.")
+            .chargers(
+                    List.of(
+                            ChargerFixture.선릉역_충전기_1번_사용가능,
+                            ChargerFixture.선릉역_충전기_2번_변경됨
+                    )
+            )
+            .build();
+
+    public static final ChargeStation 선릉역_충전소_충전기_2개_사용가능_1개_이름_변경됨 = ChargeStation.builder()
+            .stationId("ME101010")
+            .stationName("선릉역2 충전소")
+            .companyName("볼튼")
+            .isParkingFree(true)
+            .operatingTime("24시간 이용가능")
+            .detailLocation("2층")
+            .latitude(Latitude.from("38.3994933"))
+            .longitude(Longitude.from("128.3994933"))
+            .isPrivate(false)
+            .contact("02-0202-0202")
+            .stationState("yyyy-mm-dd일부터 충전소 공사합니다.")
+            .privateReason("이용 제한 사유 없습니다.")
+            .chargers(
+                    List.of(
+                            ChargerFixture.선릉역_충전기_1번_사용가능,
+                            ChargerFixture.선릉역_충전기_2번_사용_중
+                    )
+            )
+            .build();
+
+    public static final ChargeStation 선릉역_충전소_충전기_0개_사용가능_0개 = ChargeStation.builder()
+            .stationId("ME101010")
+            .stationName("선릉역 충전소")
+            .companyName("볼튼")
+            .isParkingFree(true)
+            .operatingTime("24시간 이용가능")
+            .detailLocation("2층")
+            .latitude(Latitude.from("38.3994933"))
+            .longitude(Longitude.from("128.3994933"))
+            .isPrivate(false)
+            .contact("02-0202-0202")
+            .stationState("yyyy-mm-dd일부터 충전소 공사합니다.")
+            .privateReason("이용 제한 사유 없습니다.")
+            .chargers(
+                    List.of(
+                    )
+            )
+            .build();
 }

--- a/backend/src/test/java/com/carffeine/carffeine/fixture/chargerStation/ChargerFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/fixture/chargerStation/ChargerFixture.java
@@ -41,4 +41,20 @@ public class ChargerFixture {
                     .latestUpdateTime(LocalDateTime.now())
                     .build())
             .build();
+
+    public static final Charger 선릉역_충전기_2번_변경됨 = Charger.builder()
+            .stationId("ME101010")
+            .chargerId("02")
+            .price(BigDecimal.valueOf(324.4))
+            .method("단독")
+            .address("서울특별시 강남구 선릉로100길 2 선릉역2")
+            .capacity(BigDecimal.valueOf(50.0))
+            .type("완속")
+            .chargerStatus(ChargerStatus.builder()
+                    .stationId("ME101010")
+                    .chargerId("02")
+                    .chargerState(ChargerState.CHARGING_IN_PROGRESS)
+                    .latestUpdateTime(LocalDateTime.now())
+                    .build())
+            .build();
 }

--- a/backend/src/test/java/com/carffeine/carffeine/helper/integration/IntegrationTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/helper/integration/IntegrationTest.java
@@ -1,0 +1,13 @@
+package com.carffeine.carffeine.helper.integration;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestExecutionListeners;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Retention(RetentionPolicy.RUNTIME)
+@TestExecutionListeners(value = {IntegrationTestHelper.class}, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public @interface IntegrationTest {
+}

--- a/backend/src/test/java/com/carffeine/carffeine/helper/integration/IntegrationTestHelper.java
+++ b/backend/src/test/java/com/carffeine/carffeine/helper/integration/IntegrationTestHelper.java
@@ -1,0 +1,32 @@
+package com.carffeine.carffeine.helper.integration;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+import java.util.List;
+
+public class IntegrationTestHelper extends AbstractTestExecutionListener {
+
+    @Override
+    public void afterTestMethod(TestContext testContext) throws Exception {
+        JdbcTemplate jdbcTemplate = testContext.getApplicationContext().getBean(JdbcTemplate.class);
+
+        List<String> truncateAllQueries = getQueriesForTruncateAllTables(jdbcTemplate);
+        executeTruncateTables(jdbcTemplate, truncateAllQueries);
+    }
+
+    private static void executeTruncateTables(JdbcTemplate jdbcTemplate, List<String> truncateAllTablesQuery) {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0");
+
+        for (String truncateQuery : truncateAllTablesQuery) {
+            jdbcTemplate.execute(truncateQuery);
+        }
+
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1");
+    }
+
+    private static List<String> getQueriesForTruncateAllTables(JdbcTemplate jdbcTemplate) {
+        return jdbcTemplate.queryForList("SELECT CONCAT('TRUNCATE TABLE ', TABLE_NAME, ';') AS q FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'PUBLIC'", String.class);
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/service/ChargerStationUpdateServiceUnitTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/service/ChargerStationUpdateServiceUnitTest.java
@@ -1,0 +1,126 @@
+package com.carffeine.carffeine.service;
+
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeStation;
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeStationRepository;
+import com.carffeine.carffeine.domain.chargerStation.chargeStation.ChargeUpdateJdbc;
+import com.carffeine.carffeine.fixture.chargerStation.ChargeStationFixture;
+import com.carffeine.carffeine.service.chargerStation.UpdateScrapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@ExtendWith(MockitoExtension.class)
+class ChargerStationUpdateServiceUnitTest {
+
+    @InjectMocks
+    private ChargerStationUpdateService chargerStationUpdateService;
+
+    @Mock
+    private UpdateScrapper updateScrapper;
+
+    @Mock
+    private ChargeStationRepository chargeStationRepository;
+
+    @Mock
+    private ChargeUpdateJdbc chargeUpdateJdbc;
+
+    /**
+     * 1. 충전소가 없으면 저장
+     * 2. 충전소가 변경되면 업데이트
+     * 3. 충전기가 없으면 저장
+     * 4. 충전기가 변경되면 업데이트
+     */
+
+
+    @Test
+    void 기존에_없던_충전소가_생기면_저장한다() {
+        // given
+        given(chargeStationRepository.findAll()).willReturn(new ArrayList<ChargeStation>());
+        List<ChargeStation> updateStations = List.of(ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개);
+
+        // when
+        when(updateScrapper.updateData()).thenReturn(updateStations);
+        chargerStationUpdateService.updateStations();
+
+        // then
+        assertAll(
+                () -> verify(chargeUpdateJdbc, times(1)).saveAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).updateAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).saveAllChargersBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).updateAllChargersBatch(any())
+        );
+    }
+
+    @Test
+    void 기존에_있던_충전소의_데이터가_변경되면_수정한다() {
+        // given
+        given(chargeStationRepository.findAll()).willReturn(new ArrayList<ChargeStation>(List.of(ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개)));
+        List<ChargeStation> updateStations = List.of(ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개_이름_변경됨);
+
+        // when
+        when(updateScrapper.updateData()).thenReturn(updateStations);
+        chargerStationUpdateService.updateStations();
+
+        // then
+        assertAll(
+                () -> verify(chargeUpdateJdbc, times(0)).saveAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(1)).updateAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).saveAllChargersBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).updateAllChargersBatch(any())
+        );
+    }
+
+    @Test
+    void 기존에_없던_충전기가_생기면_저장한다() {
+        // given
+        given(chargeStationRepository.findAll()).willReturn(new ArrayList<ChargeStation>(List.of(ChargeStationFixture.선릉역_충전소_충전기_0개_사용가능_0개)));
+        List<ChargeStation> updateStations = List.of(ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개);
+
+        // when
+        when(updateScrapper.updateData()).thenReturn(updateStations);
+        chargerStationUpdateService.updateStations();
+
+        // then
+        assertAll(
+                () -> verify(chargeUpdateJdbc, times(0)).saveAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).updateAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(1)).saveAllChargersBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).updateAllChargersBatch(any())
+        );
+    }
+
+    @Test
+    void 기존에_있던_충전기의_데이터가_변경되면_수정한다() {
+        // given
+        given(chargeStationRepository.findAll()).willReturn(new ArrayList<ChargeStation>(List.of(ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개)));
+        List<ChargeStation> updateStations = List.of(ChargeStationFixture.선릉역_충전소_충전기_2개_사용가능_1개_완속);
+
+        // when
+        when(updateScrapper.updateData()).thenReturn(updateStations);
+        chargerStationUpdateService.updateStations();
+
+        // then
+        assertAll(
+                () -> verify(chargeUpdateJdbc, times(0)).saveAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).updateAllStationsBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(0)).saveAllChargersBatch(any()),
+                () -> verify(chargeUpdateJdbc, times(1)).updateAllChargersBatch(any())
+        );
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  flyway:
+    enabled: false
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+  #        use_sql_comments: true


### PR DESCRIPTION
## 📄 Summary
> 통합 테스트에서 테스트 격리를 위한 기능을 구현했습니다.
따라서 테스트를 격리시키기 위해서 기존의 방법인 `@Sql 어노테이션으로 매 번 작성한 sql문을 로드해서 테스트마다 테이블을 초기화` 시켜주지 않으셔도 됩니다.

밑에 예제처럼 `@IntegrationTest`라는 어노테이션 하나를 붙이면 `@SpringBootTest(RANDOM_PORT)` + `@Sql() : Tables Truncate`을 자동으로 해줍니다.

따라서 포트 지정만 신경써주시면 됩니다.

테스트용 yml 설정파일이 없어서 h2 기반으로 하나 만들었습니다.

## 🙋🏻 More
>  사용 예제
``` java
@IntegrationTest
public class Example {

    @LocalServerPort
    private int port;

    @BeforeEach
    void init() {
        RestAssured.port = port;
    }

    @Test
    void example() {
        // 포트는 직접 지정하면 됩니다. 자동으로 테스트 격리 및 @Sql문 필요 없습니다.
    }
}

```


close #76