### PR TITLE
refactor: useExternalState의 setState를 개선한다

### DIFF
--- a/frontend/src/components/google-maps/marker/StationMarker.tsx
+++ b/frontend/src/components/google-maps/marker/StationMarker.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 
 import { useExternalValue, useSetExternalState } from '@utils/external-state';
-import { getStoreSnapshot } from '@utils/external-state/tools';
 
 import { getBriefStationInfoWindowStore } from '@stores/briefStationInfoWindowStore';
 import { markerInstanceStore } from '@stores/markerInstanceStore';
@@ -34,9 +33,8 @@ const StationMarker = ({ googleMap, station }: Props) => {
       title: stationName,
     });
 
-    const prevMarkerInstances = getStoreSnapshot(markerInstanceStore);
-    setMarkerInstanceState([
-      ...prevMarkerInstances,
+    setMarkerInstanceState((previewsMarkerInstances) => [
+      ...previewsMarkerInstances,
       {
         stationId,
         markerInstance,
@@ -55,8 +53,7 @@ const StationMarker = ({ googleMap, station }: Props) => {
     });
 
     return () => {
-      const prevMarkerInstances = getStoreSnapshot(markerInstanceStore);
-      setMarkerInstanceState(
+      setMarkerInstanceState((prevMarkerInstances) =>
         prevMarkerInstances.filter((stationMarker) => stationMarker.stationId !== stationId)
       );
 

--- a/frontend/src/utils/external-state/StateManager.ts
+++ b/frontend/src/utils/external-state/StateManager.ts
@@ -1,5 +1,7 @@
+type SetStateCallback<T> = (newState: T) => T;
+
 export interface DataObserver<T> {
-  setState: (newState: T) => void;
+  setState: (param: SetStateCallback<T> | T) => void;
   getState: () => T;
   subscribe: (listener: () => void) => () => void;
   emitChange: () => void;
@@ -13,8 +15,13 @@ class StateManager<T> implements DataObserver<T> {
     this.state = initialState;
   }
 
-  setState = (newState: T) => {
-    this.state = newState;
+  setState = (param: SetStateCallback<T> | T) => {
+    if (param instanceof Function) {
+      const newState = param(this.state);
+      this.state = newState;
+    } else {
+      this.state = param;
+    }
 
     this.emitChange();
   };

--- a/frontend/src/utils/external-state/StateManager.ts
+++ b/frontend/src/utils/external-state/StateManager.ts
@@ -1,4 +1,4 @@
-type SetStateCallback<T> = (newState: T) => T;
+type SetStateCallback<T> = (prevState: T) => T;
 
 export interface DataObserver<T> {
   setState: (param: SetStateCallback<T> | T) => void;

--- a/frontend/src/utils/external-state/tools.ts
+++ b/frontend/src/utils/external-state/tools.ts
@@ -3,7 +3,7 @@ import { useSyncExternalStore } from 'react';
 import StateManager from './StateManager';
 import type { DataObserver } from './StateManager';
 
-export const store = <T>(initialState: T): StateManager<T> => {
+export const store = <T>(initialState: T) => {
   const stateManager = new StateManager<T>(initialState);
 
   return stateManager;
@@ -16,19 +16,19 @@ export const useExternalState = <T>(store: DataObserver<T>): [T, (newState: T) =
   return [state, setState];
 };
 
-export const useSetExternalState = <T>(store: DataObserver<T>): ((newState: T) => void) => {
+export const useSetExternalState = <T>(store: DataObserver<T>) => {
   const { setState } = store;
 
   return setState;
 };
 
-export const useExternalValue = <T>(store: DataObserver<T>): T => {
+export const useExternalValue = <T>(store: DataObserver<T>) => {
   const { subscribe, getState } = store;
   const state = useSyncExternalStore(subscribe, getState);
 
   return state;
 };
 
-export const getStoreSnapshot = <T>(store: DataObserver<T>): T => {
+export const getStoreSnapshot = <T>(store: DataObserver<T>) => {
   return store.getState();
 };


### PR DESCRIPTION
## 📄 Summary
- [x] StateManager 클래스의 setState 메서드의 타입을 수정한다.
- [x] setState를 실행할 때 콜백함수가 전달 되었을 때, 새로운 state가 전달되었을 때를 분기처리하여 처리하도록 수정한다.
- [x] 콜백 함수가 전달되었을 때 인자로 this.state를 전달해준다.
- [x] 이전 값을 참조하기 위해 getStoreSnapShot을 사용했던 부분을 콜백함수 전달로 수정한다.

## 🙋🏻 More
> 실제 소요 시간: 30분


close #100