### PR TITLE
refactor: google map을 전달하는 구조를 개선한다

### DIFF
--- a/frontend/src/components/google-maps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/google-maps/map/CarFfeineMap.tsx
@@ -4,7 +4,7 @@ import StationMarkersContainer from '@marker/StationMarkersContainer';
 
 import { useExternalValue } from '@utils/external-state';
 
-import { googleMapStore } from '@stores/googleMapStore';
+import { getGoogleMapStore } from '@stores/googleMapStore';
 
 import { useUpdateStations } from '@hooks/useUpdateStations';
 
@@ -26,7 +26,7 @@ const CarFfeineMap = () => {
 
 const CarFfeineMapListener = () => {
   const { updateStations } = useUpdateStations();
-  const googleMap = useExternalValue(googleMapStore());
+  const googleMap = useExternalValue(getGoogleMapStore());
 
   useEffect(() => {
     googleMap.addListener('dragend', () => {

--- a/frontend/src/components/google-maps/map/CarFfeineMap.tsx
+++ b/frontend/src/components/google-maps/map/CarFfeineMap.tsx
@@ -1,64 +1,32 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import StationMarkersContainer from '@marker/StationMarkersContainer';
-import UserMarker from '@marker/UserMarker';
 
-import { useExternalState } from '@utils/external-state';
+import { useExternalValue } from '@utils/external-state';
 
 import { googleMapStore } from '@stores/googleMapStore';
 
-import { useCurrentPosition } from '@hooks/useCurrentPosition';
 import { useUpdateStations } from '@hooks/useUpdateStations';
 
 import MarkerList from '@ui/MarkerList';
 import StationList from '@ui/StationList';
 import ZoomController from '@ui/ZoomController';
 
-import { INITIAL_ZOOM_SIZE } from '@constants';
-
-interface Props {
-  googleMap: google.maps.Map;
-}
-
 const CarFfeineMap = () => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [googleMap, setGoogleMap] = useExternalState<google.maps.Map>(googleMapStore);
-
-  const position = useCurrentPosition();
-
-  const isClientReady = position !== undefined && googleMap;
-
-  useEffect(() => {
-    if (position != undefined) {
-      const initialMap = new window.google.maps.Map(ref.current, {
-        center: position,
-        zoom: INITIAL_ZOOM_SIZE,
-        disableDefaultUI: true,
-      });
-
-      setGoogleMap(initialMap);
-    }
-  }, [position]);
-
   return (
     <>
-      <div ref={ref} id="map" style={{ minHeight: '100vh' }} />
-      {isClientReady && (
-        <>
-          <CarFfeineMapListener googleMap={googleMap} />
-          <StationMarkersContainer googleMap={googleMap} />
-          <UserMarker googleMap={googleMap} position={position} />
-          <StationList />
-          <MarkerList />
-          <ZoomController />
-        </>
-      )}
+      <CarFfeineMapListener />
+      <StationMarkersContainer />
+      <StationList />
+      <MarkerList />
+      <ZoomController />
     </>
   );
 };
 
-const CarFfeineMapListener = ({ googleMap }: Props) => {
+const CarFfeineMapListener = () => {
   const { updateStations } = useUpdateStations();
+  const googleMap = useExternalValue(googleMapStore());
 
   useEffect(() => {
     googleMap.addListener('dragend', () => {

--- a/frontend/src/components/google-maps/marker/StationMarker.tsx
+++ b/frontend/src/components/google-maps/marker/StationMarker.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useExternalValue, useSetExternalState } from '@utils/external-state';
 
 import { getBriefStationInfoWindowStore } from '@stores/briefStationInfoWindowStore';
+import { googleMapStore } from '@stores/googleMapStore';
 import { markerInstanceStore } from '@stores/markerInstanceStore';
 
 import { useUpdateStations } from '@hooks/useUpdateStations';
@@ -12,12 +13,12 @@ import BriefStationInfo from '@ui/BriefStationInfo';
 import type { Station } from 'types';
 
 interface Props {
-  googleMap: google.maps.Map;
   station: Station;
 }
 
-const StationMarker = ({ googleMap, station }: Props) => {
+const StationMarker = ({ station }: Props) => {
   const { latitude, longitude, stationName, stationId } = station;
+  const googleMap = useExternalValue(googleMapStore());
 
   const { updateStations } = useUpdateStations();
   const { briefStationInfoRoot, infoWindowInstance } = useExternalValue(

--- a/frontend/src/components/google-maps/marker/StationMarker.tsx
+++ b/frontend/src/components/google-maps/marker/StationMarker.tsx
@@ -3,7 +3,7 @@ import { useEffect } from 'react';
 import { useExternalValue, useSetExternalState } from '@utils/external-state';
 
 import { getBriefStationInfoWindowStore } from '@stores/briefStationInfoWindowStore';
-import { googleMapStore } from '@stores/googleMapStore';
+import { getGoogleMapStore } from '@stores/googleMapStore';
 import { markerInstanceStore } from '@stores/markerInstanceStore';
 
 import { useUpdateStations } from '@hooks/useUpdateStations';
@@ -18,7 +18,7 @@ interface Props {
 
 const StationMarker = ({ station }: Props) => {
   const { latitude, longitude, stationName, stationId } = station;
-  const googleMap = useExternalValue(googleMapStore());
+  const googleMap = useExternalValue(getGoogleMapStore());
 
   const { updateStations } = useUpdateStations();
   const { briefStationInfoRoot, infoWindowInstance } = useExternalValue(

--- a/frontend/src/components/google-maps/marker/StationMarkersContainer.tsx
+++ b/frontend/src/components/google-maps/marker/StationMarkersContainer.tsx
@@ -1,12 +1,13 @@
+import { useExternalValue } from '@utils/external-state';
+
+import { googleMapStore } from '@stores/googleMapStore';
+
 import { useStations } from '@hooks/useStations';
 
 import StationMarker from './StationMarker';
 
-interface Props {
-  googleMap: google.maps.Map;
-}
-
-const StationMarkersContainer = ({ googleMap }: Props) => {
+const StationMarkersContainer = () => {
+  const googleMap = useExternalValue(googleMapStore());
   const { data: stations, isSuccess } = useStations(googleMap);
 
   if (!stations || !isSuccess) {
@@ -16,7 +17,7 @@ const StationMarkersContainer = ({ googleMap }: Props) => {
   return (
     <>
       {stations.map((station) => {
-        return <StationMarker key={station.stationId} googleMap={googleMap} station={station} />;
+        return <StationMarker key={station.stationId} station={station} />;
       })}
     </>
   );

--- a/frontend/src/components/google-maps/marker/StationMarkersContainer.tsx
+++ b/frontend/src/components/google-maps/marker/StationMarkersContainer.tsx
@@ -1,13 +1,13 @@
 import { useExternalValue } from '@utils/external-state';
 
-import { googleMapStore } from '@stores/googleMapStore';
+import { getGoogleMapStore } from '@stores/googleMapStore';
 
 import { useStations } from '@hooks/useStations';
 
 import StationMarker from './StationMarker';
 
 const StationMarkersContainer = () => {
-  const googleMap = useExternalValue(googleMapStore());
+  const googleMap = useExternalValue(getGoogleMapStore());
   const { data: stations, isSuccess } = useStations(googleMap);
 
   if (!stations || !isSuccess) {

--- a/frontend/src/components/ui/StationList.tsx
+++ b/frontend/src/components/ui/StationList.tsx
@@ -14,7 +14,7 @@ import BriefStationInfo from './BriefStationInfo';
 import type { Station } from 'types';
 
 const StationList = () => {
-  const googleMap = useExternalValue(googleMapStore);
+  const googleMap = useExternalValue(googleMapStore());
 
   const { data: stations, isSuccess, isFetching } = useStations(googleMap);
   const stationMarkers = useExternalValue(markerInstanceStore);

--- a/frontend/src/components/ui/StationList.tsx
+++ b/frontend/src/components/ui/StationList.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components';
 import { useExternalValue } from '@utils/external-state';
 
 import { getBriefStationInfoWindowStore } from '@stores/briefStationInfoWindowStore';
-import { googleMapStore } from '@stores/googleMapStore';
+import { getGoogleMapStore } from '@stores/googleMapStore';
 import { markerInstanceStore } from '@stores/markerInstanceStore';
 
 import { useStations } from '@hooks/useStations';
@@ -14,7 +14,7 @@ import BriefStationInfo from './BriefStationInfo';
 import type { Station } from 'types';
 
 const StationList = () => {
-  const googleMap = useExternalValue(googleMapStore());
+  const googleMap = useExternalValue(getGoogleMapStore());
 
   const { data: stations, isSuccess, isFetching } = useStations(googleMap);
   const stationMarkers = useExternalValue(markerInstanceStore);

--- a/frontend/src/stores/googleMapStore.ts
+++ b/frontend/src/stores/googleMapStore.ts
@@ -1,15 +1,38 @@
 import { store } from '@utils/external-state';
 
-export const googleMapStore = store<google.maps.Map>(null);
+import { INITIAL_CENTER, INITIAL_ZOOM_SIZE } from '@constants';
+
+export const googleMapStore = (() => {
+  let googleMap: google.maps.Map;
+
+  const mapDiv = document.createElement('div');
+
+  mapDiv.id = 'map';
+  mapDiv.style.minHeight = '100vh';
+
+  document.body.appendChild(mapDiv);
+
+  return () => {
+    if (!googleMap) {
+      googleMap = new window.google.maps.Map(mapDiv, {
+        center: INITIAL_CENTER,
+        zoom: INITIAL_ZOOM_SIZE,
+        disableDefaultUI: true,
+      });
+    }
+
+    return store<google.maps.Map>(googleMap);
+  };
+})();
 
 export const googleMapActions = {
   zoomUp: () => {
-    const googleMap = googleMapStore.getState();
+    const googleMap = googleMapStore().getState();
     const prevZoom = googleMap.getZoom();
     googleMap.setZoom(prevZoom + 1);
   },
   zoomDown: () => {
-    const googleMap = googleMapStore.getState();
+    const googleMap = googleMapStore().getState();
     const prevZoom = googleMap.getZoom();
     googleMap.setZoom(prevZoom - 1);
   },

--- a/frontend/src/stores/googleMapStore.ts
+++ b/frontend/src/stores/googleMapStore.ts
@@ -5,16 +5,16 @@ import { INITIAL_CENTER, INITIAL_ZOOM_SIZE } from '@constants';
 export const getGoogleMapStore = (() => {
   let googleMap: google.maps.Map;
 
-  const mapDiv = document.createElement('div');
+  const container = document.createElement('div');
 
-  mapDiv.id = 'map';
-  mapDiv.style.minHeight = '100vh';
+  container.id = 'map';
+  container.style.minHeight = '100vh';
 
-  document.body.appendChild(mapDiv);
+  document.body.appendChild(container);
 
   return () => {
     if (!googleMap) {
-      googleMap = new window.google.maps.Map(mapDiv, {
+      googleMap = new window.google.maps.Map(container, {
         center: INITIAL_CENTER,
         zoom: INITIAL_ZOOM_SIZE,
         disableDefaultUI: true,

--- a/frontend/src/stores/googleMapStore.ts
+++ b/frontend/src/stores/googleMapStore.ts
@@ -2,7 +2,7 @@ import { store } from '@utils/external-state';
 
 import { INITIAL_CENTER, INITIAL_ZOOM_SIZE } from '@constants';
 
-export const googleMapStore = (() => {
+export const getGoogleMapStore = (() => {
   let googleMap: google.maps.Map;
 
   const mapDiv = document.createElement('div');
@@ -27,12 +27,12 @@ export const googleMapStore = (() => {
 
 export const googleMapActions = {
   zoomUp: () => {
-    const googleMap = googleMapStore().getState();
+    const googleMap = getGoogleMapStore().getState();
     const prevZoom = googleMap.getZoom();
     googleMap.setZoom(prevZoom + 1);
   },
   zoomDown: () => {
-    const googleMap = googleMapStore().getState();
+    const googleMap = getGoogleMapStore().getState();
     const prevZoom = googleMap.getZoom();
     googleMap.setZoom(prevZoom - 1);
   },


### PR DESCRIPTION
## 📄 Summary
> - [x] google maps api에 지도 렌더링 요청을 보낼 때 필요한 DOM 요소를 추가한다.
> - [x] 클로져를 활용해 최초 생성시에만 지도 렌더링 요청을 보내도록 한다.
> - [x] googleMap을 Props로 넘겨받는 모든 컴포넌트를 전역 상태에서 googleMap을 참조하는 방식으로 구조를 수정한다.

## 🙋🏻 More
> 실제 소요 시간: 1시간


close #110