### PR TITLE
fix: husky가 mac에서 작동하지 않는 오류를 개선한다

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "cypress": "cypress open",
-    "prepare": "cd .. && husky install frontend/.husky && cd frontend"
+    "prepare": "cd .. && husky install frontend/.husky && cd frontend",
+    "prepare:mac": "cd .. && husky install frontend/.husky && chmod +x frontend/.husky/* && git update-index --chmod=+x && cd frontend"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
[#136]

## 📄 Summary
> mac 전용 prepare script(`prepare:mac`)를 추가해 권한을 허용해줌으로써 에러를 개선했다.


close #136