### PR TITLE
refactor: Text variant type 지정

### DIFF
--- a/frontend/src/components/common/Text/Text.tsx
+++ b/frontend/src/components/common/Text/Text.tsx
@@ -1,7 +1,18 @@
 import styled, { css } from 'styled-components';
 
 const Text = styled.p<{
-  variant?: string;
+  variant?:
+    | 'h1'
+    | 'h2'
+    | 'h3'
+    | 'h4'
+    | 'h5'
+    | 'h6'
+    | 'title'
+    | 'subtitle'
+    | 'label'
+    | 'body'
+    | 'caption';
   mb?: number;
   align?: 'center' | 'left' | 'right';
 }>`


### PR DESCRIPTION
[#192]

## 📄 Summary
> 타입 추론이 좀 더 쉬워지는 업데이트를 하였습니다
### From
```typescript
  variant?: string;
```

### To
```typescript
  variant?:
    | 'h1'
    | 'h2'
    | 'h3'
    | 'h4'
    | 'h5'
    | 'h6'
    | 'title'
    | 'subtitle'
    | 'label'
    | 'body'
    | 'caption';
```

`<Text variant=`
이렇게 개선하면 여기까지만 입력해도 IDE에서 타입 추천을 받을 수 있습니다.

## 🕰️ Actual Time of Completion
> 1분

## 🙋🏻 More
> 


close #192