### PR TITLE
fix: 지도 이동 시 중복으로 데이터를 요청하는 문제 수정

### DIFF
--- a/frontend/src/hooks/useUpdateStations.ts
+++ b/frontend/src/hooks/useUpdateStations.ts
@@ -6,7 +6,6 @@ export const useUpdateStations = () => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(['stations'], {
-    mutationFn: fetchStation,
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['stations'] });
     },


### PR DESCRIPTION
## 📄 Summary
> tanstack-query의 중복 요청 버그를 수정합니다.

## 🕰️ Actual Time of Completion
> 1분

## 🙋🏻 More
> 


close #121