### PR TITLE
refactor: 실제 url에 연결하고 development 모드에서 서버를 유동적으로 선택할 수 있도록 개선한다

### DIFF
--- a/frontend/src/components/ui/Accordion/Navigator.tsx
+++ b/frontend/src/components/ui/Accordion/Navigator.tsx
@@ -10,6 +10,7 @@ import { useContext } from 'react';
 import Button from '@common/Button';
 import FlexBox from '@common/FlexBox';
 
+import DevelopmentServerControlButton from '@ui/DevelopmentServerControlButton';
 import MswControlButton from '@ui/MswControlButton';
 import LogoIcon from '@ui/Svg/LogoIcon';
 
@@ -48,6 +49,7 @@ const Navigator = () => {
         <Bars3Icon width="2.8rem" stroke="#333" />
       </Button>
       {process.env.NODE_ENV === 'development' && <MswControlButton />}
+      {process.env.NODE_ENV === 'development' && <DevelopmentServerControlButton />}
     </FlexBox>
   );
 };

--- a/frontend/src/components/ui/Accordion/Navigator.tsx
+++ b/frontend/src/components/ui/Accordion/Navigator.tsx
@@ -49,7 +49,6 @@ const Navigator = () => {
         <Bars3Icon width="2.8rem" stroke="#333" />
       </Button>
       {process.env.NODE_ENV === 'development' && <MswControlButton />}
-      {process.env.NODE_ENV === 'development' && <DevelopmentServerControlButton />}
     </FlexBox>
   );
 };

--- a/frontend/src/components/ui/DevelopmentServerControlButton.tsx
+++ b/frontend/src/components/ui/DevelopmentServerControlButton.tsx
@@ -1,19 +1,24 @@
-import { modalActions } from '@stores/modalStore';
+import { useExternalValue } from '@utils/external-state';
+
+import { developmentServerActions, developmentServerStore } from '@stores/developmentServerStore';
 
 import Button from '@common/Button';
 import Text from '@common/Text';
 
-import DevelopmentServerSelect from '@ui/DevelopmentServerSelect';
-
 const DevelopmentServerControlButton = () => {
-  const handleDevelopmentServerControlButton = () => {
-    modalActions.openModal(<DevelopmentServerSelect />);
+  const currentServer = useExternalValue(developmentServerStore);
+
+  const handleClickDevelopmentServerControlButton = () => {
+    developmentServerActions.changeServer(currentServer === 'localhost' ? 'dain' : 'localhost');
   };
 
   return (
-    <Button onClick={handleDevelopmentServerControlButton}>
+    <Button onClick={handleClickDevelopmentServerControlButton}>
       <>
-        <Text align="center">하이</Text>
+        <Text align="center">현재서버</Text>
+        <Text align="center" variant="caption">
+          {currentServer}
+        </Text>
       </>
     </Button>
   );

--- a/frontend/src/components/ui/DevelopmentServerControlButton.tsx
+++ b/frontend/src/components/ui/DevelopmentServerControlButton.tsx
@@ -1,0 +1,22 @@
+import { modalActions } from '@stores/modalStore';
+
+import Button from '@common/Button';
+import Text from '@common/Text';
+
+import DevelopmentServerSelect from '@ui/DevelopmentServerSelect';
+
+const DevelopmentServerControlButton = () => {
+  const handleDevelopmentServerControlButton = () => {
+    modalActions.openModal(<DevelopmentServerSelect />);
+  };
+
+  return (
+    <Button onClick={handleDevelopmentServerControlButton}>
+      <>
+        <Text align="center">하이</Text>
+      </>
+    </Button>
+  );
+};
+
+export default DevelopmentServerControlButton;

--- a/frontend/src/components/ui/DevelopmentServerControlButton.tsx
+++ b/frontend/src/components/ui/DevelopmentServerControlButton.tsx
@@ -1,15 +1,15 @@
 import { useExternalValue } from '@utils/external-state';
 
-import { developmentServerActions, developmentServerStore } from '@stores/developmentServerStore';
+import { serverActions, serverStore } from '@stores/serverStore';
 
 import Button from '@common/Button';
 import Text from '@common/Text';
 
 const DevelopmentServerControlButton = () => {
-  const currentServer = useExternalValue(developmentServerStore);
+  const currentServer = useExternalValue(serverStore);
 
   const handleClickDevelopmentServerControlButton = () => {
-    developmentServerActions.changeServer(currentServer === 'localhost' ? 'dain' : 'localhost');
+    serverActions.changeServer(currentServer === 'localhost' ? 'dain' : 'localhost');
   };
 
   return (

--- a/frontend/src/components/ui/DevelopmentServerSelect.tsx
+++ b/frontend/src/components/ui/DevelopmentServerSelect.tsx
@@ -5,11 +5,11 @@ import { developmentServerActions, developmentServerStore } from '@stores/develo
 import Button from '@common/Button';
 import Text from '@common/Text';
 
-import type { servers } from '@constants';
+import type { SERVERS } from '@constants';
 
 const DevelopmentServerSelect = () => {
   const currentServer = useExternalValue(developmentServerStore);
-  const changeServer = (nextServer: keyof typeof servers) => {
+  const changeServer = (nextServer: keyof typeof SERVERS) => {
     developmentServerActions.changeServer(nextServer);
   };
 

--- a/frontend/src/components/ui/DevelopmentServerSelect.tsx
+++ b/frontend/src/components/ui/DevelopmentServerSelect.tsx
@@ -1,0 +1,5 @@
+const DevelopmentServerSelect = () => {
+  return <></>;
+};
+
+export default DevelopmentServerSelect;

--- a/frontend/src/components/ui/DevelopmentServerSelect.tsx
+++ b/frontend/src/components/ui/DevelopmentServerSelect.tsx
@@ -1,5 +1,29 @@
+import { useExternalValue } from '@utils/external-state';
+
+import { developmentServerActions, developmentServerStore } from '@stores/developmentServerStore';
+
+import Button from '@common/Button';
+import Text from '@common/Text';
+
+import type { servers } from '@constants';
+
 const DevelopmentServerSelect = () => {
-  return <></>;
+  const currentServer = useExternalValue(developmentServerStore);
+  const changeServer = (nextServer: keyof typeof servers) => {
+    developmentServerActions.changeServer(nextServer);
+  };
+
+  return (
+    <>
+      <Text>{currentServer}</Text>
+      <Button outlined size="sm" onClick={() => changeServer('localhost')}>
+        <Text>localhost</Text>
+      </Button>
+      <Button outlined size="sm" onClick={() => changeServer('dain')}>
+        <Text>dain</Text>
+      </Button>
+    </>
+  );
 };
 
 export default DevelopmentServerSelect;

--- a/frontend/src/components/ui/DevelopmentServerSelect.tsx
+++ b/frontend/src/components/ui/DevelopmentServerSelect.tsx
@@ -1,6 +1,6 @@
 import { useExternalValue } from '@utils/external-state';
 
-import { developmentServerActions, developmentServerStore } from '@stores/developmentServerStore';
+import { serverActions, serverStore } from '@stores/serverStore';
 
 import Button from '@common/Button';
 import Text from '@common/Text';
@@ -8,9 +8,9 @@ import Text from '@common/Text';
 import type { SERVERS } from '@constants';
 
 const DevelopmentServerSelect = () => {
-  const currentServer = useExternalValue(developmentServerStore);
+  const currentServer = useExternalValue(serverStore);
   const changeServer = (nextServer: keyof typeof SERVERS) => {
-    developmentServerActions.changeServer(nextServer);
+    serverActions.changeServer(nextServer);
   };
 
   return (

--- a/frontend/src/components/ui/MswControlButton.tsx
+++ b/frontend/src/components/ui/MswControlButton.tsx
@@ -1,28 +1,39 @@
 import { useState } from 'react';
 
+import { useSetExternalState } from '@utils/external-state';
+
+import { developmentServerStore } from '@stores/developmentServerStore';
+
 import Button from '@common/Button';
 import Text from '@common/Text';
+
+import DevelopmentServerControlButton from '@ui/DevelopmentServerControlButton';
 
 import { startMsw, stopMsw } from '../../mocks/configureMsw';
 
 const MswControlButton = () => {
   const [isMswMode, setMswMode] = useState(true);
+  const setDevelopmentServer = useSetExternalState(developmentServerStore);
   const switchMswMode = async () => {
     setMswMode(!isMswMode);
     if (isMswMode) {
       await stopMsw();
     } else {
+      setDevelopmentServer('localhost');
       await startMsw();
     }
   };
 
   return (
-    <Button onClick={() => switchMswMode()}>
-      <>
-        <Text align="center">MSW</Text>
-        <Text align="center">{isMswMode ? 'ON' : 'OFF'}</Text>
-      </>
-    </Button>
+    <>
+      <Button onClick={() => switchMswMode()}>
+        <>
+          <Text align="center">MSW</Text>
+          <Text align="center">{isMswMode ? 'ON' : 'OFF'}</Text>
+        </>
+      </Button>
+      {!isMswMode && <DevelopmentServerControlButton />}
+    </>
   );
 };
 

--- a/frontend/src/components/ui/MswControlButton.tsx
+++ b/frontend/src/components/ui/MswControlButton.tsx
@@ -1,3 +1,5 @@
+import { startMsw, stopMsw } from '@mocks/configureMsw';
+
 import { useState } from 'react';
 
 import { useSetExternalState } from '@utils/external-state';
@@ -8,8 +10,6 @@ import Button from '@common/Button';
 import Text from '@common/Text';
 
 import DevelopmentServerControlButton from '@ui/DevelopmentServerControlButton';
-
-import { startMsw, stopMsw } from '../../mocks/configureMsw';
 
 const MswControlButton = () => {
   const [isMswMode, setMswMode] = useState(true);

--- a/frontend/src/components/ui/MswControlButton.tsx
+++ b/frontend/src/components/ui/MswControlButton.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { useSetExternalState } from '@utils/external-state';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
+import { serverStore } from '@stores/serverStore';
 
 import Button from '@common/Button';
 import Text from '@common/Text';
@@ -13,7 +13,7 @@ import DevelopmentServerControlButton from '@ui/DevelopmentServerControlButton';
 
 const MswControlButton = () => {
   const [isMswMode, setMswMode] = useState(true);
-  const setDevelopmentServer = useSetExternalState(developmentServerStore);
+  const setDevelopmentServer = useSetExternalState(serverStore);
   const switchMswMode = async () => {
     setMswMode(!isMswMode);
     if (isMswMode) {

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -9,18 +9,18 @@ export const INITIAL_ZOOM_SIZE = 14;
 
 export const INVALID_VALUE_LIST = ['null', '.', '..', '1', '#'] as const;
 
-export const DEVELOP_URL = 'http://localhost:8080/api';
-export const PRODUCTION_URL = 'http://1.1.1.1:8080/api';
+// export const DEVELOP_URL = 'http://localhost:8080/api';
+// export const PRODUCTION_URL = 'http://1.1.1.1:8080/api';
 
-type ModeType = 'development' | 'production';
+// type ModeType = 'development' | 'production';
 
-const URL: Readonly<Record<ModeType, string>> = {
-  development: DEVELOP_URL,
-  production: PRODUCTION_URL,
-};
+// const URL: Readonly<Record<ModeType, string>> = {
+//   development: DEVELOP_URL,
+//   production: PRODUCTION_URL,
+// };
 
-const MODE = process.env.NODE_ENV as ModeType;
-export const BASE_URL = URL[MODE];
+// const MODE = process.env.NODE_ENV as ModeType;
+// export const BASE_URL = URL[MODE];
 
 const ERROR_PREFIX = '[error]';
 export const ERROR_MESSAGES = {
@@ -186,4 +186,5 @@ export const MAX_SEARCH_RESULTS = 10;
 export const servers = {
   localhost: 'http://localhost:8080/api',
   dain: 'https://dain.carffe.in/api',
+  production: 'https://api.carffe.in/api',
 } as const;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -182,3 +182,8 @@ export const SEARCH_SCOPE =
   '&scope=stationName&scope=address&scope=speed&scope=latitude&scope=longitude';
 
 export const MAX_SEARCH_RESULTS = 10;
+
+export const servers = {
+  localhost: 'http://localhost:8080/api',
+  dain: 'https://dain.carffe.in/api',
+} as const;

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -9,19 +9,6 @@ export const INITIAL_ZOOM_SIZE = 14;
 
 export const INVALID_VALUE_LIST = ['null', '.', '..', '1', '#'] as const;
 
-// export const DEVELOP_URL = 'http://localhost:8080/api';
-// export const PRODUCTION_URL = 'http://1.1.1.1:8080/api';
-
-// type ModeType = 'development' | 'production';
-
-// const URL: Readonly<Record<ModeType, string>> = {
-//   development: DEVELOP_URL,
-//   production: PRODUCTION_URL,
-// };
-
-// const MODE = process.env.NODE_ENV as ModeType;
-// export const BASE_URL = URL[MODE];
-
 const ERROR_PREFIX = '[error]';
 export const ERROR_MESSAGES = {
   NO_STATION_FOUND: `${ERROR_PREFIX} 해당 충전소가 존재하지 않습니다.`,
@@ -183,7 +170,7 @@ export const SEARCH_SCOPE =
 
 export const MAX_SEARCH_RESULTS = 10;
 
-export const servers = {
+export const SERVERS = {
   localhost: 'http://localhost:8080/api',
   dain: 'https://dain.carffe.in/api',
   production: 'https://api.carffe.in/api',

--- a/frontend/src/hooks/useSearchedStations.ts
+++ b/frontend/src/hooks/useSearchedStations.ts
@@ -2,15 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useExternalValue } from '@utils/external-state';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
 import { searchWordStore } from '@stores/searchWordStore';
+import { serverStore } from '@stores/serverStore';
 
 import { ERROR_MESSAGES, SEARCH_SCOPE, SERVERS } from '@constants';
 
 import type { SearchedStation, SearchedStationResponse } from 'types';
 
 export const fetchSearchedStations = async (searchWord: string) => {
-  const mode = developmentServerStore.getState();
+  const mode = serverStore.getState();
   const searchedStations = await fetch(
     `${SERVERS[mode]}/stations/search?q=${searchWord}${SEARCH_SCOPE}`,
     {

--- a/frontend/src/hooks/useSearchedStations.ts
+++ b/frontend/src/hooks/useSearchedStations.ts
@@ -2,15 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useExternalValue } from '@utils/external-state';
 
+import { developmentServerStore } from '@stores/developmentServerStore';
 import { searchWordStore } from '@stores/searchWordStore';
 
-import { DEVELOP_URL, ERROR_MESSAGES, SEARCH_SCOPE } from '@constants';
+import { ERROR_MESSAGES, SEARCH_SCOPE, servers } from '@constants';
 
 import type { SearchedStation, SearchedStationResponse } from 'types';
 
 export const fetchSearchedStations = async (searchWord: string) => {
+  const mode = developmentServerStore.getState();
   const searchedStations = await fetch(
-    `${DEVELOP_URL}/stations/search?q=${searchWord}${SEARCH_SCOPE}`,
+    `${servers[mode]}/stations/search?q=${searchWord}${SEARCH_SCOPE}`,
     {
       method: 'GET',
     }

--- a/frontend/src/hooks/useSearchedStations.ts
+++ b/frontend/src/hooks/useSearchedStations.ts
@@ -5,14 +5,14 @@ import { useExternalValue } from '@utils/external-state';
 import { developmentServerStore } from '@stores/developmentServerStore';
 import { searchWordStore } from '@stores/searchWordStore';
 
-import { ERROR_MESSAGES, SEARCH_SCOPE, servers } from '@constants';
+import { ERROR_MESSAGES, SEARCH_SCOPE, SERVERS } from '@constants';
 
 import type { SearchedStation, SearchedStationResponse } from 'types';
 
 export const fetchSearchedStations = async (searchWord: string) => {
   const mode = developmentServerStore.getState();
   const searchedStations = await fetch(
-    `${servers[mode]}/stations/search?q=${searchWord}${SEARCH_SCOPE}`,
+    `${SERVERS[mode]}/stations/search?q=${searchWord}${SEARCH_SCOPE}`,
     {
       method: 'GET',
     }

--- a/frontend/src/hooks/useSelectedStation.ts
+++ b/frontend/src/hooks/useSelectedStation.ts
@@ -5,14 +5,14 @@ import { useExternalValue } from '@utils/external-state';
 import { developmentServerStore } from '@stores/developmentServerStore';
 import { selectedStationIdStore } from '@stores/selectedStationStore';
 
-import { ERROR_MESSAGES, INVALID_VALUE_LIST, servers } from '@constants';
+import { ERROR_MESSAGES, INVALID_VALUE_LIST, SERVERS } from '@constants';
 
 import type { StationDetails } from 'types';
 
 export const fetchStationDetails = async (selectedStationId: number) => {
   const mode = developmentServerStore.getState();
 
-  const stationDetails = await fetch(`${servers[mode]}/stations/${selectedStationId}`, {
+  const stationDetails = await fetch(`${SERVERS[mode]}/stations/${selectedStationId}`, {
     method: 'GET',
   }).then<StationDetails>(async (response) => {
     if (!response.ok) {

--- a/frontend/src/hooks/useSelectedStation.ts
+++ b/frontend/src/hooks/useSelectedStation.ts
@@ -2,14 +2,17 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useExternalValue } from '@utils/external-state';
 
+import { developmentServerStore } from '@stores/developmentServerStore';
 import { selectedStationIdStore } from '@stores/selectedStationStore';
 
-import { BASE_URL, ERROR_MESSAGES, INVALID_VALUE_LIST } from '@constants';
+import { ERROR_MESSAGES, INVALID_VALUE_LIST, servers } from '@constants';
 
 import type { StationDetails } from 'types';
 
 export const fetchStationDetails = async (selectedStationId: number) => {
-  const stationDetails = await fetch(`${BASE_URL}/stations/${selectedStationId}`, {
+  const mode = developmentServerStore.getState();
+
+  const stationDetails = await fetch(`${servers[mode]}/stations/${selectedStationId}`, {
     method: 'GET',
   }).then<StationDetails>(async (response) => {
     if (!response.ok) {

--- a/frontend/src/hooks/useSelectedStation.ts
+++ b/frontend/src/hooks/useSelectedStation.ts
@@ -2,15 +2,15 @@ import { useQuery } from '@tanstack/react-query';
 
 import { useExternalValue } from '@utils/external-state';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
 import { selectedStationIdStore } from '@stores/selectedStationStore';
+import { serverStore } from '@stores/serverStore';
 
 import { ERROR_MESSAGES, INVALID_VALUE_LIST, SERVERS } from '@constants';
 
 import type { StationDetails } from 'types';
 
 export const fetchStationDetails = async (selectedStationId: number) => {
-  const mode = developmentServerStore.getState();
+  const mode = serverStore.getState();
 
   const stationDetails = await fetch(`${SERVERS[mode]}/stations/${selectedStationId}`, {
     method: 'GET',

--- a/frontend/src/hooks/useStationChargerReport.ts
+++ b/frontend/src/hooks/useStationChargerReport.ts
@@ -2,10 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getLocalStorage } from '@utils/storage';
 
-import { DEFAULT_TOKEN, DEVELOP_URL, LOCAL_KEY_TOKEN } from '@constants';
+import { developmentServerStore } from '@stores/developmentServerStore';
 
-const fetchStationChargerReport = (token: number, stationId: number) =>
-  fetch(`${DEVELOP_URL}/stations/${stationId}/reports/me`, {
+import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, servers } from '@constants';
+
+const fetchStationChargerReport = (token: number, stationId: number) => {
+  const mode = developmentServerStore.getState();
+
+  return fetch(`${servers[mode]}/stations/${stationId}/reports/me`, {
     method: 'GET',
     headers: {
       Authorization: `${token}`,
@@ -15,6 +19,7 @@ const fetchStationChargerReport = (token: number, stationId: number) =>
     const data = await response.json();
     return data.isReported;
   });
+};
 
 export const useStationChargerReport = (stationId: number) => {
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);

--- a/frontend/src/hooks/useStationChargerReport.ts
+++ b/frontend/src/hooks/useStationChargerReport.ts
@@ -4,12 +4,12 @@ import { getLocalStorage } from '@utils/storage';
 
 import { developmentServerStore } from '@stores/developmentServerStore';
 
-import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, servers } from '@constants';
+import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, SERVERS } from '@constants';
 
 const fetchStationChargerReport = (token: number, stationId: number) => {
   const mode = developmentServerStore.getState();
 
-  return fetch(`${servers[mode]}/stations/${stationId}/reports/me`, {
+  return fetch(`${SERVERS[mode]}/stations/${stationId}/reports/me`, {
     method: 'GET',
     headers: {
       Authorization: `${token}`,

--- a/frontend/src/hooks/useStationChargerReport.ts
+++ b/frontend/src/hooks/useStationChargerReport.ts
@@ -2,12 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getLocalStorage } from '@utils/storage';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
+import { serverStore } from '@stores/serverStore';
 
 import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, SERVERS } from '@constants';
 
 const fetchStationChargerReport = (token: number, stationId: number) => {
-  const mode = developmentServerStore.getState();
+  const mode = serverStore.getState();
 
   return fetch(`${SERVERS[mode]}/stations/${stationId}/reports/me`, {
     method: 'GET',

--- a/frontend/src/hooks/useStations.ts
+++ b/frontend/src/hooks/useStations.ts
@@ -7,6 +7,7 @@ import { getTypedObjectKeys } from '@utils/getTypedObjectKeys';
 import { getDisplayPosition } from '@utils/google-maps';
 import { getQueryFormattedUrl } from '@utils/request-query-params';
 
+import { developmentServerStore } from '@stores/developmentServerStore';
 import { getGoogleMapStore } from '@stores/googleMapStore';
 import {
   selectedCapacitiesFilterStore,
@@ -15,7 +16,7 @@ import {
 } from '@stores/selectedServerStationFiltersStore';
 import { stationFilterStore } from '@stores/stationFilterStore';
 
-import { BASE_URL } from '@constants';
+import { servers } from '@constants';
 
 import type { DisplayPosition, StationSummary } from 'types';
 
@@ -37,7 +38,8 @@ export const fetchStation = async () => {
     chargerTypes: getStoreSnapshot(selectedChargerTypesFilterStore).join(','),
   });
 
-  const stations = await fetch(`${BASE_URL}/stations?${requestQueryParams}`, {
+  const mode = developmentServerStore.getState();
+  const stations = await fetch(`${servers[mode]}/stations?${requestQueryParams}`, {
     method: 'GET',
   }).then<StationSummary[]>(async (response) => {
     const data = await response.json();

--- a/frontend/src/hooks/useStations.ts
+++ b/frontend/src/hooks/useStations.ts
@@ -7,13 +7,13 @@ import { getTypedObjectKeys } from '@utils/getTypedObjectKeys';
 import { getDisplayPosition } from '@utils/google-maps';
 import { getQueryFormattedUrl } from '@utils/request-query-params';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
 import { getGoogleMapStore } from '@stores/googleMapStore';
 import {
   selectedCapacitiesFilterStore,
   selectedChargerTypesFilterStore,
   selectedCompanyNamesFilterStore,
 } from '@stores/selectedServerStationFiltersStore';
+import { serverStore } from '@stores/serverStore';
 import { stationFilterStore } from '@stores/stationFilterStore';
 
 import { SERVERS } from '@constants';
@@ -38,7 +38,7 @@ export const fetchStation = async () => {
     chargerTypes: getStoreSnapshot(selectedChargerTypesFilterStore).join(','),
   });
 
-  const mode = developmentServerStore.getState();
+  const mode = serverStore.getState();
   const stations = await fetch(`${SERVERS[mode]}/stations?${requestQueryParams}`, {
     method: 'GET',
   }).then<StationSummary[]>(async (response) => {

--- a/frontend/src/hooks/useStations.ts
+++ b/frontend/src/hooks/useStations.ts
@@ -16,7 +16,7 @@ import {
 } from '@stores/selectedServerStationFiltersStore';
 import { stationFilterStore } from '@stores/stationFilterStore';
 
-import { servers } from '@constants';
+import { SERVERS } from '@constants';
 
 import type { DisplayPosition, StationSummary } from 'types';
 
@@ -39,7 +39,7 @@ export const fetchStation = async () => {
   });
 
   const mode = developmentServerStore.getState();
-  const stations = await fetch(`${servers[mode]}/stations?${requestQueryParams}`, {
+  const stations = await fetch(`${SERVERS[mode]}/stations?${requestQueryParams}`, {
     method: 'GET',
   }).then<StationSummary[]>(async (response) => {
     const data = await response.json();

--- a/frontend/src/hooks/useUpdateStationChargerReport.ts
+++ b/frontend/src/hooks/useUpdateStationChargerReport.ts
@@ -5,12 +5,12 @@ import { getLocalStorage } from '@utils/storage';
 import { developmentServerStore } from '@stores/developmentServerStore';
 import { modalActions } from '@stores/modalStore';
 
-import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, servers } from '@constants';
+import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, SERVERS } from '@constants';
 
 const fetchReportCharger = async (stationId: number) => {
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);
   const mode = developmentServerStore.getState();
-  return fetch(`${servers[mode]}/stations/${stationId}/reports`, {
+  return fetch(`${SERVERS[mode]}/stations/${stationId}/reports`, {
     method: 'POST',
     headers: {
       Authorization: `${token}`,

--- a/frontend/src/hooks/useUpdateStationChargerReport.ts
+++ b/frontend/src/hooks/useUpdateStationChargerReport.ts
@@ -2,13 +2,15 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { getLocalStorage } from '@utils/storage';
 
+import { developmentServerStore } from '@stores/developmentServerStore';
 import { modalActions } from '@stores/modalStore';
 
-import { BASE_URL, DEFAULT_TOKEN, LOCAL_KEY_TOKEN } from '@constants';
+import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, servers } from '@constants';
 
 const fetchReportCharger = async (stationId: number) => {
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);
-  return fetch(`${BASE_URL}/stations/${stationId}/reports`, {
+  const mode = developmentServerStore.getState();
+  return fetch(`${servers[mode]}/stations/${stationId}/reports`, {
     method: 'POST',
     headers: {
       Authorization: `${token}`,

--- a/frontend/src/hooks/useUpdateStationChargerReport.ts
+++ b/frontend/src/hooks/useUpdateStationChargerReport.ts
@@ -2,14 +2,14 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { getLocalStorage } from '@utils/storage';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
 import { modalActions } from '@stores/modalStore';
+import { serverStore } from '@stores/serverStore';
 
 import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, SERVERS } from '@constants';
 
 const fetchReportCharger = async (stationId: number) => {
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);
-  const mode = developmentServerStore.getState();
+  const mode = serverStore.getState();
   return fetch(`${SERVERS[mode]}/stations/${stationId}/reports`, {
     method: 'POST',
     headers: {

--- a/frontend/src/hooks/useUpdateStationReport.ts
+++ b/frontend/src/hooks/useUpdateStationReport.ts
@@ -2,11 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 
 import { getLocalStorage } from '@utils/storage';
 
+import { developmentServerStore } from '@stores/developmentServerStore';
 import { modalActions } from '@stores/modalStore';
 
 import type { Differences } from '@ui/DetailedStationInfo/StationReportConfirmation';
 
-import { BASE_URL, DEFAULT_TOKEN, LOCAL_KEY_TOKEN } from '@constants';
+import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, servers } from '@constants';
 
 interface fetchReportStationRequest {
   stationId: number;
@@ -16,7 +17,8 @@ interface fetchReportStationRequest {
 const fetchReportStation = async (fetchReportStationRequestParams: fetchReportStationRequest) => {
   const { stationId, differences } = fetchReportStationRequestParams;
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);
-  return fetch(`${BASE_URL}/stations/${stationId}/misinformation-reports`, {
+  const mode = developmentServerStore.getState();
+  return fetch(`${servers[mode]}/stations/${stationId}/misinformation-reports`, {
     method: 'POST',
     headers: {
       Authorization: `${token}`,

--- a/frontend/src/hooks/useUpdateStationReport.ts
+++ b/frontend/src/hooks/useUpdateStationReport.ts
@@ -2,8 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 
 import { getLocalStorage } from '@utils/storage';
 
-import { developmentServerStore } from '@stores/developmentServerStore';
 import { modalActions } from '@stores/modalStore';
+import { serverStore } from '@stores/serverStore';
 
 import type { Differences } from '@ui/DetailedStationInfo/StationReportConfirmation';
 
@@ -17,7 +17,7 @@ interface fetchReportStationRequest {
 const fetchReportStation = async (fetchReportStationRequestParams: fetchReportStationRequest) => {
   const { stationId, differences } = fetchReportStationRequestParams;
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);
-  const mode = developmentServerStore.getState();
+  const mode = serverStore.getState();
   return fetch(`${SERVERS[mode]}/stations/${stationId}/misinformation-reports`, {
     method: 'POST',
     headers: {

--- a/frontend/src/hooks/useUpdateStationReport.ts
+++ b/frontend/src/hooks/useUpdateStationReport.ts
@@ -7,7 +7,7 @@ import { modalActions } from '@stores/modalStore';
 
 import type { Differences } from '@ui/DetailedStationInfo/StationReportConfirmation';
 
-import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, servers } from '@constants';
+import { DEFAULT_TOKEN, LOCAL_KEY_TOKEN, SERVERS } from '@constants';
 
 interface fetchReportStationRequest {
   stationId: number;
@@ -18,7 +18,7 @@ const fetchReportStation = async (fetchReportStationRequestParams: fetchReportSt
   const { stationId, differences } = fetchReportStationRequestParams;
   const token = getLocalStorage<number>(LOCAL_KEY_TOKEN, DEFAULT_TOKEN);
   const mode = developmentServerStore.getState();
-  return fetch(`${servers[mode]}/stations/${stationId}/misinformation-reports`, {
+  return fetch(`${SERVERS[mode]}/stations/${stationId}/misinformation-reports`, {
     method: 'POST',
     headers: {
       Authorization: `${token}`,

--- a/frontend/src/hooks/useUpdateStations.ts
+++ b/frontend/src/hooks/useUpdateStations.ts
@@ -1,11 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { fetchStation } from './useStations';
-
 export const useUpdateStations = () => {
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation(['stations'], {
+    mutationFn: () => new Promise<Response>(() => new Response()),
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['stations'] });
     },

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2,14 +2,14 @@ import { rest } from 'msw';
 
 import { getSessionStorage, setSessionStorage } from '@utils/storage';
 
-import { DEVELOP_URL, ERROR_MESSAGES, SESSION_KEY_REPORTED_STATIONS } from '@constants';
+import { ERROR_MESSAGES, servers, SESSION_KEY_REPORTED_STATIONS } from '@constants';
 
 import { getSearchedStations, stations } from './data';
 
 import type { StationSummary } from 'types';
 
 export const handlers = [
-  rest.get(`${DEVELOP_URL}/stations`, async (req, res, ctx) => {
+  rest.get(`${servers.localhost}/stations`, async (req, res, ctx) => {
     const { searchParams } = req.url;
 
     const latitude = Number(searchParams.get('latitude'));
@@ -80,7 +80,7 @@ export const handlers = [
     );
   }),
 
-  rest.get(`${DEVELOP_URL}/stations/search`, async (req, res, ctx) => {
+  rest.get(`${servers.localhost}/stations/search`, async (req, res, ctx) => {
     const searchWord = req.url.searchParams.get('q');
 
     if (!stations.length) {
@@ -94,7 +94,7 @@ export const handlers = [
     return res(ctx.delay(200), ctx.status(200), ctx.json(searchResult));
   }),
 
-  rest.get(`${DEVELOP_URL}/stations/:id`, async (req, res, ctx) => {
+  rest.get(`${servers.localhost}/stations/:id`, async (req, res, ctx) => {
     const stationId = Number(req.params.id);
     const selectedStation = stations.find((station) => station.stationId === stationId);
 
@@ -105,7 +105,7 @@ export const handlers = [
     return res(ctx.delay(200), ctx.status(200), ctx.json(selectedStation));
   }),
 
-  rest.post(`${DEVELOP_URL}/stations/:stationId/reports`, (req, res, ctx) => {
+  rest.post(`${servers.localhost}/stations/:stationId/reports`, (req, res, ctx) => {
     const stationId = Number(req.params.stationId);
     const prevReportedStations = getSessionStorage<number[]>(SESSION_KEY_REPORTED_STATIONS, []);
 
@@ -116,7 +116,7 @@ export const handlers = [
     return res(ctx.delay(200), ctx.status(204));
   }),
 
-  rest.get(`${DEVELOP_URL}/stations/:stationId/reports/me`, (req, res, ctx) => {
+  rest.get(`${servers.localhost}/stations/:stationId/reports/me`, (req, res, ctx) => {
     console.log(req.headers.get('Authorization')); // TODO: 이후에 비로그인 기능도 구현할 때 활용해야함
     const stationId = Number(req.params.stationId);
     const reportedStations = getSessionStorage<number[]>(SESSION_KEY_REPORTED_STATIONS, []);
@@ -128,10 +128,13 @@ export const handlers = [
     );
   }),
 
-  rest.post(`${DEVELOP_URL}/stations/:stationId/misinformation-reports`, async (req, res, ctx) => {
-    const body = await req.json();
-    console.log(JSON.stringify(body.stationDetailsToUpdate));
+  rest.post(
+    `${servers.localhost}/stations/:stationId/misinformation-reports`,
+    async (req, res, ctx) => {
+      const body = await req.json();
+      console.log(JSON.stringify(body.stationDetailsToUpdate));
 
-    return res(ctx.delay(200), ctx.status(204));
-  }),
+      return res(ctx.delay(200), ctx.status(204));
+    }
+  ),
 ];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -2,14 +2,14 @@ import { rest } from 'msw';
 
 import { getSessionStorage, setSessionStorage } from '@utils/storage';
 
-import { ERROR_MESSAGES, servers, SESSION_KEY_REPORTED_STATIONS } from '@constants';
+import { ERROR_MESSAGES, SERVERS, SESSION_KEY_REPORTED_STATIONS } from '@constants';
 
 import { getSearchedStations, stations } from './data';
 
 import type { StationSummary } from 'types';
 
 export const handlers = [
-  rest.get(`${servers.localhost}/stations`, async (req, res, ctx) => {
+  rest.get(`${SERVERS.localhost}/stations`, async (req, res, ctx) => {
     const { searchParams } = req.url;
 
     const latitude = Number(searchParams.get('latitude'));
@@ -80,7 +80,7 @@ export const handlers = [
     );
   }),
 
-  rest.get(`${servers.localhost}/stations/search`, async (req, res, ctx) => {
+  rest.get(`${SERVERS.localhost}/stations/search`, async (req, res, ctx) => {
     const searchWord = req.url.searchParams.get('q');
 
     if (!stations.length) {
@@ -94,7 +94,7 @@ export const handlers = [
     return res(ctx.delay(200), ctx.status(200), ctx.json(searchResult));
   }),
 
-  rest.get(`${servers.localhost}/stations/:id`, async (req, res, ctx) => {
+  rest.get(`${SERVERS.localhost}/stations/:id`, async (req, res, ctx) => {
     const stationId = Number(req.params.id);
     const selectedStation = stations.find((station) => station.stationId === stationId);
 
@@ -105,7 +105,7 @@ export const handlers = [
     return res(ctx.delay(200), ctx.status(200), ctx.json(selectedStation));
   }),
 
-  rest.post(`${servers.localhost}/stations/:stationId/reports`, (req, res, ctx) => {
+  rest.post(`${SERVERS.localhost}/stations/:stationId/reports`, (req, res, ctx) => {
     const stationId = Number(req.params.stationId);
     const prevReportedStations = getSessionStorage<number[]>(SESSION_KEY_REPORTED_STATIONS, []);
 
@@ -116,7 +116,7 @@ export const handlers = [
     return res(ctx.delay(200), ctx.status(204));
   }),
 
-  rest.get(`${servers.localhost}/stations/:stationId/reports/me`, (req, res, ctx) => {
+  rest.get(`${SERVERS.localhost}/stations/:stationId/reports/me`, (req, res, ctx) => {
     console.log(req.headers.get('Authorization')); // TODO: 이후에 비로그인 기능도 구현할 때 활용해야함
     const stationId = Number(req.params.stationId);
     const reportedStations = getSessionStorage<number[]>(SESSION_KEY_REPORTED_STATIONS, []);
@@ -129,7 +129,7 @@ export const handlers = [
   }),
 
   rest.post(
-    `${servers.localhost}/stations/:stationId/misinformation-reports`,
+    `${SERVERS.localhost}/stations/:stationId/misinformation-reports`,
     async (req, res, ctx) => {
       const body = await req.json();
       console.log(JSON.stringify(body.stationDetailsToUpdate));

--- a/frontend/src/stores/developmentServerStore.ts
+++ b/frontend/src/stores/developmentServerStore.ts
@@ -1,13 +1,13 @@
 import { store } from '@utils/external-state';
 
-import type { servers } from '@constants';
+import type { SERVERS } from '@constants';
 
-export const developmentServerStore = store<keyof typeof servers>(
+export const developmentServerStore = store<keyof typeof SERVERS>(
   process.env.NODE_ENV === 'production' ? 'production' : 'localhost'
 );
 
 export const developmentServerActions = {
-  changeServer: (nextServer: keyof typeof servers) => {
+  changeServer: (nextServer: keyof typeof SERVERS) => {
     developmentServerStore.setState(nextServer);
   },
 };

--- a/frontend/src/stores/developmentServerStore.ts
+++ b/frontend/src/stores/developmentServerStore.ts
@@ -1,0 +1,11 @@
+import { store } from '@utils/external-state';
+
+import type { servers } from '@constants';
+
+export const developmentServerStore = store<keyof typeof servers>('localhost');
+
+export const developmentServerActions = {
+  changeServer: (nextServer: keyof typeof servers) => {
+    developmentServerStore.setState(nextServer);
+  },
+};

--- a/frontend/src/stores/developmentServerStore.ts
+++ b/frontend/src/stores/developmentServerStore.ts
@@ -2,7 +2,9 @@ import { store } from '@utils/external-state';
 
 import type { servers } from '@constants';
 
-export const developmentServerStore = store<keyof typeof servers>('localhost');
+export const developmentServerStore = store<keyof typeof servers>(
+  process.env.NODE_ENV === 'production' ? 'production' : 'localhost'
+);
 
 export const developmentServerActions = {
   changeServer: (nextServer: keyof typeof servers) => {

--- a/frontend/src/stores/serverStore.ts
+++ b/frontend/src/stores/serverStore.ts
@@ -2,12 +2,12 @@ import { store } from '@utils/external-state';
 
 import type { SERVERS } from '@constants';
 
-export const developmentServerStore = store<keyof typeof SERVERS>(
+export const serverStore = store<keyof typeof SERVERS>(
   process.env.NODE_ENV === 'production' ? 'production' : 'localhost'
 );
 
-export const developmentServerActions = {
+export const serverActions = {
   changeServer: (nextServer: keyof typeof SERVERS) => {
-    developmentServerStore.setState(nextServer);
+    serverStore.setState(nextServer);
   },
 };


### PR DESCRIPTION
## 📄 Summary
> 기존의 BASE_URL을 제거하고, 새로운 형태의 url 접근 방법을 제공합니다.

production 모드에 영향을 주지 않으면서 원하는 서버로 유동적으로 연결할 수 있는 기능을 구현하였습니다.
dev서버(dain)에 선택적으로 연결하여 테스트가 가능하며, 기존에 로컬에서 테스트 하는 것도 유지할 수 있도록 하였습니다.

## 🕰️ Actual Time of Completion
> 1시간

## 🙋🏻 More
> 


close #293