### PR TITLE
feat: 충전소 상세 정보 컴포넌트에 누적 혼잡도 시각화 컴포넌트를 렌더링 한다

### DIFF
--- a/frontend/src/components/ui/Accordion/Navigator.tsx
+++ b/frontend/src/components/ui/Accordion/Navigator.tsx
@@ -5,20 +5,15 @@ import {
 } from '@heroicons/react/24/outline';
 import { css } from 'styled-components';
 
-import { useContext } from 'react';
-
 import Button from '@common/Button';
 import FlexBox from '@common/FlexBox';
 
-import DevelopmentServerControlButton from '@ui/DevelopmentServerControlButton';
 import MswControlButton from '@ui/MswControlButton';
 import LogoIcon from '@ui/Svg/LogoIcon';
 
-import { AccordionContext } from '.';
 import { useAccordionAction } from './hooks/useAccordionAction';
 
 const Navigator = () => {
-  const { basePanelType } = useContext(AccordionContext);
   const { toggleOpenBasePanel: handleOpenBasePanel } = useAccordionAction();
 
   return (

--- a/frontend/src/components/ui/DetailedStationInfo/CongestionStatistics.tsx
+++ b/frontend/src/components/ui/DetailedStationInfo/CongestionStatistics.tsx
@@ -16,8 +16,13 @@ const CongestionStatistics = () => {
   const { data: congestionStatistics, isFetching } = useStationCongestionStatistics();
   const [chargingSpeed, setChargingSpeed] = useState<'QUICK' | 'STANDARD'>('QUICK');
 
+  // TODO: 그래프 모양 로딩 스켈레톤 추가하기
   if (isFetching) {
-    return <FlexBox>loading...</FlexBox>;
+    return (
+      <FlexBox width="100%" height="50rem" justifyContent="center" alignItems="center">
+        <Text variant="h2">⌛</Text>
+      </FlexBox>
+    );
   }
 
   return (

--- a/frontend/src/components/ui/DetailedStationInfo/CongestionStatistics.tsx
+++ b/frontend/src/components/ui/DetailedStationInfo/CongestionStatistics.tsx
@@ -10,11 +10,12 @@ import Text from '@common/Text';
 
 import StatisticsGraph from '@ui/StatisticsGraph';
 
+import type { CHARGING_SPEED } from '@constants';
 import { ENGLISH_DAYS } from '@constants';
 
 const CongestionStatistics = () => {
   const { data: congestionStatistics, isFetching } = useStationCongestionStatistics();
-  const [chargingSpeed, setChargingSpeed] = useState<'QUICK' | 'STANDARD'>('QUICK');
+  const [chargingSpeed, setChargingSpeed] = useState<keyof typeof CHARGING_SPEED>('QUICK');
 
   // TODO: 그래프 모양 로딩 스켈레톤 추가하기
   if (isFetching) {

--- a/frontend/src/components/ui/DetailedStationInfo/CongestionStatistics.tsx
+++ b/frontend/src/components/ui/DetailedStationInfo/CongestionStatistics.tsx
@@ -1,0 +1,63 @@
+import { css } from 'styled-components';
+
+import { useState } from 'react';
+
+import { useStationCongestionStatistics } from '@hooks/useStationCongestionStatistics';
+
+import Button from '@common/Button';
+import FlexBox from '@common/FlexBox';
+import Text from '@common/Text';
+
+import StatisticsGraph from '@ui/StatisticsGraph';
+
+import { ENGLISH_DAYS } from '@constants';
+
+const CongestionStatistics = () => {
+  const { data: congestionStatistics, isFetching } = useStationCongestionStatistics();
+  const [chargingSpeed, setChargingSpeed] = useState<'QUICK' | 'STANDARD'>('QUICK');
+
+  if (isFetching) {
+    return <FlexBox>loading...</FlexBox>;
+  }
+
+  return (
+    <FlexBox direction="column" gap={4}>
+      <FlexBox justifyContent="between">
+        <Button
+          background={chargingSpeed === 'QUICK' && '#0064ff'}
+          width="48%"
+          outlined
+          css={buttonBorderColorCss}
+          onClick={() => setChargingSpeed('QUICK')}
+        >
+          <Text variant="h6" color={chargingSpeed === 'QUICK' && '#fff'}>
+            급속 보기
+          </Text>
+        </Button>
+        <Button
+          background={chargingSpeed === 'STANDARD' && '#0064ff'}
+          color={chargingSpeed === 'STANDARD' && '#fff'}
+          width="48%"
+          outlined
+          css={buttonBorderColorCss}
+          onClick={() => setChargingSpeed('STANDARD')}
+        >
+          <Text variant="h6" color={chargingSpeed === 'STANDARD' && '#fff'}>
+            완속 보기
+          </Text>
+        </Button>
+      </FlexBox>
+      <StatisticsGraph
+        statistics={congestionStatistics.congestion[chargingSpeed]}
+        menus={[...ENGLISH_DAYS]}
+        align="column"
+      />
+    </FlexBox>
+  );
+};
+
+const buttonBorderColorCss = css`
+  border: 1px solid #d4d4d4;
+`;
+
+export default CongestionStatistics;

--- a/frontend/src/components/ui/DetailedStationInfo/DetailedStation.tsx
+++ b/frontend/src/components/ui/DetailedStationInfo/DetailedStation.tsx
@@ -15,6 +15,7 @@ import StationInformation from '@ui/DetailedStationInfo/StationInformation';
 import StationReportConfirmation from '@ui/DetailedStationInfo/StationReportConfirmation';
 
 import type { StationDetails } from '../../../types';
+import CongestionStatistics from './CongestionStatistics';
 
 export interface DetailedStationProps {
   station: StationDetails;
@@ -27,7 +28,7 @@ const DetailedStation = ({ station }: DetailedStationProps) => {
     useStationChargerReport(stationId);
 
   return (
-    <Box px={2} pt={10} css={containerCss}>
+    <Box px={2} py={10} css={containerCss}>
       <StationInformation station={station} />
       <FlexBox justifyContent="center">
         <Button
@@ -68,6 +69,7 @@ const DetailedStation = ({ station }: DetailedStationProps) => {
           <Alert color={'secondary'} text={`충전 상태 불일치 신고가 ${reportCount}번 접수됐어요`} />
         </Box>
       )}
+      <CongestionStatistics />
     </Box>
   );
 };

--- a/frontend/src/components/ui/StatisticsGraph/StatisticsGraph.stories.tsx
+++ b/frontend/src/components/ui/StatisticsGraph/StatisticsGraph.stories.tsx
@@ -1,4 +1,4 @@
-import { congestions } from '@mocks/data';
+import { getCongestionStatistics } from '@mocks/data';
 import type { Meta } from '@storybook/react';
 
 import { ENGLISH_DAYS } from '@constants';
@@ -16,7 +16,7 @@ export default meta;
 export const Column = () => {
   return (
     <StatisticsGraph
-      statistics={congestions.congestion.QUICK}
+      statistics={getCongestionStatistics(1).congestion.QUICK}
       align="column"
       menus={[...ENGLISH_DAYS]}
     />
@@ -26,7 +26,7 @@ export const Column = () => {
 export const Row = () => {
   return (
     <StatisticsGraph
-      statistics={congestions.congestion.QUICK}
+      statistics={getCongestionStatistics(1).congestion.QUICK}
       align="row"
       menus={[...ENGLISH_DAYS]}
     />

--- a/frontend/src/hooks/useStationCongestionStatistics.ts
+++ b/frontend/src/hooks/useStationCongestionStatistics.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { useExternalValue } from '@utils/external-state';
+
+import { selectedStationIdStore } from '@stores/selectedStationStore';
+import { serverStore } from '@stores/serverStore';
+
+import { ERROR_MESSAGES, SERVERS } from '@constants';
+
+import type { CongestionStatistics } from 'types';
+
+export const fetchStationDetails = async (selectedStationId: number) => {
+  const mode = serverStore.getState();
+
+  const stationDetails = await fetch(`${SERVERS[mode]}/stations/${selectedStationId}/statistics`, {
+    method: 'GET',
+  }).then<CongestionStatistics>(async (response) => {
+    if (!response.ok) {
+      throw new Error(ERROR_MESSAGES.STATION_DETAILS_FETCH_ERROR);
+    }
+
+    const congestionStatistics: CongestionStatistics = await response.json();
+
+    return congestionStatistics;
+  });
+
+  return stationDetails;
+};
+
+export const useStationCongestionStatistics = () => {
+  const selectedStationId = useExternalValue(selectedStationIdStore);
+
+  return useQuery({
+    queryKey: ['stationCongestionStatistics', selectedStationId],
+    queryFn: () => fetchStationDetails(selectedStationId),
+    enabled: !!selectedStationId,
+  });
+};

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -7,7 +7,9 @@ import type {
   CapacityType,
   ChargerDetails,
   CompanyName,
+  Congestion,
   CongestionStatistics,
+  EnglishDaysType,
   MockStation,
 } from '../types';
 import type { ChargerType } from '../types';
@@ -92,22 +94,26 @@ export const getSearchedStations = (searchWord: string) => {
     .slice(0, MAX_SEARCH_RESULTS);
 };
 
-const congestionObject = getTypedObjectFromEntries(
-  ENGLISH_DAYS,
-  ENGLISH_DAYS.map(() =>
-    Array.from({ length: 24 }).map((_, i) => {
-      return {
-        hour: i,
-        ratio: Math.floor(Math.random() * 102 - 1),
-      };
-    })
-  )
-);
+export const getCongestionStatistics = (stationId: number): CongestionStatistics => {
+  return {
+    stationId,
+    congestion: {
+      QUICK: getCongestions(),
+      STANDARD: getCongestions(),
+    },
+  };
+};
 
-export const congestions: CongestionStatistics = {
-  stationId: 0,
-  congestion: {
-    QUICK: congestionObject,
-    STANDARD: congestionObject,
-  },
+const getCongestions = (): Record<EnglishDaysType, Congestion[]> => {
+  return getTypedObjectFromEntries(
+    ENGLISH_DAYS,
+    ENGLISH_DAYS.map(() =>
+      Array.from({ length: 24 }).map((_, i) => {
+        return {
+          hour: i,
+          ratio: Math.floor(Math.random() * 102 - 1),
+        };
+      })
+    )
+  );
 };

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -145,6 +145,6 @@ export const handlers = [
 
     const congestionStatistics = getCongestionStatistics(stationId);
 
-    return res(ctx.json(congestionStatistics), ctx.delay(200), ctx.status(200));
+    return res(ctx.json(congestionStatistics), ctx.delay(1000), ctx.status(200));
   }),
 ];

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -4,7 +4,7 @@ import { getSessionStorage, setSessionStorage } from '@utils/storage';
 
 import { ERROR_MESSAGES, SERVERS, SESSION_KEY_REPORTED_STATIONS } from '@constants';
 
-import { getSearchedStations, stations } from './data';
+import { getCongestionStatistics, getSearchedStations, stations } from './data';
 
 import type { StationSummary } from 'types';
 
@@ -137,4 +137,14 @@ export const handlers = [
       return res(ctx.delay(200), ctx.status(204));
     }
   ),
+
+  rest.get(`${SERVERS.localhost}/stations/:stationId/statistics`, (req, res, ctx) => {
+    const stationId = Number(
+      req.url.pathname.replace(/\/api\/stations\//, '').replace(/\/statistics/, '')
+    );
+
+    const congestionStatistics = getCongestionStatistics(stationId);
+
+    return res(ctx.json(congestionStatistics), ctx.delay(200), ctx.status(200));
+  }),
 ];


### PR DESCRIPTION
## 📄 Summary
> - [x] 누적 혼잡도 mock api를 구현한다.
> - [x] mock api에 요청을 발생시켜 충전소 세부 정보에 누적 혼잡도 시각화 컴포넌트를 렌더링한다.

## 🕰️ Actual Time of Completion
> 3시간

## 🙋🏻 More
>  로딩 스켈레톤


close #233