### PR TITLE
fix: 상세정보가 없을 때도 상세정보창이 남아있는 오류 수정

### DIFF
--- a/frontend/src/components/ui/DetailedStationInfo/DetailedStationInfo.tsx
+++ b/frontend/src/components/ui/DetailedStationInfo/DetailedStationInfo.tsx
@@ -3,6 +3,7 @@ import { useSelectedStation } from '@hooks/useSelectedStation';
 import Box from '@common/Box';
 import Text from '@common/Text';
 
+import { useAccordionAction } from '@ui/Accordion/hooks/useAccordionAction';
 import DetailedStation from '@ui/DetailedStationInfo/DetailedStation';
 
 const DetailedStationInfo = () => {
@@ -10,7 +11,13 @@ const DetailedStationInfo = () => {
     data: selectedStation,
     isLoading: isSelectedStationLoading,
     isError: isSelectedStationError,
+    isFetching,
   } = useSelectedStation();
+  const { handleCloseLastPanel } = useAccordionAction();
+
+  if (!isFetching && selectedStation === undefined) {
+    handleCloseLastPanel();
+  }
 
   if (isSelectedStationError || isSelectedStationLoading) {
     return (

--- a/frontend/src/components/ui/StationList/StationSummaryCard.tsx
+++ b/frontend/src/components/ui/StationList/StationSummaryCard.tsx
@@ -1,9 +1,5 @@
 import { css } from 'styled-components';
 
-import { useSetExternalState } from '@utils/external-state';
-
-import { selectedStationIdStore } from '@stores/selectedStationStore';
-
 import { useStationSummary } from '@hooks/useStationSummary';
 
 import Button from '@common/Button';

--- a/frontend/src/hooks/useSelectedStation.ts
+++ b/frontend/src/hooks/useSelectedStation.ts
@@ -10,6 +10,10 @@ import { ERROR_MESSAGES, INVALID_VALUE_LIST, SERVERS } from '@constants';
 import type { StationDetails } from 'types';
 
 export const fetchStationDetails = async (selectedStationId: number) => {
+  if (selectedStationId === null) {
+    throw new Error('선택된 충전소가 없습니다.');
+  }
+
   const mode = serverStore.getState();
 
   const stationDetails = await fetch(`${SERVERS[mode]}/stations/${selectedStationId}`, {

--- a/frontend/src/hooks/useStationCongestionStatistics.ts
+++ b/frontend/src/hooks/useStationCongestionStatistics.ts
@@ -21,8 +21,6 @@ export const fetchStationDetails = async (selectedStationId: number) => {
 
     const congestionStatistics: CongestionStatistics = await response.json();
 
-    console.log(congestionStatistics);
-
     return congestionStatistics;
   });
 


### PR DESCRIPTION
[#356]

## 📄 Summary
> 상세 정보를 보고 있던 충전소가 화면 바깥으로 나갔을 때 상세 정보창이 계속 열려있는 버그 수정

## 🕰️ Actual Time of Completion
> 30분

## 🙋🏻 More
> 


close #356