### PR TITLE
refactor: context-path를 설정함으로 '/api'를 작성하지 않아도 prefix로 고정되도록 변경

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/member/controller/MemberController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/controller/MemberController.java
@@ -5,11 +5,9 @@ import com.carffeine.carffeine.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping
 @RequiredArgsConstructor
 public class MemberController {
 

--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/congestion/CongestionController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/congestion/CongestionController.java
@@ -15,7 +15,7 @@ public class CongestionController {
 
     private final CongestionService congestionService;
 
-    @GetMapping("/api/stations/{stationId}/statistics")
+    @GetMapping("/stations/{stationId}/statistics")
     public ResponseEntity<StatisticsResponse> showCongestionStatistics(@PathVariable String stationId) {
         StatisticsResponse statisticsResponse = congestionService.calculateCongestion(new StatisticsRequest(stationId));
         return ResponseEntity.ok(statisticsResponse);

--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/report/ReportController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/report/ReportController.java
@@ -18,7 +18,7 @@ public class ReportController {
 
     private final ReportService reportService;
 
-    @PostMapping("/api/stations/{stationId}/reports")
+    @PostMapping("/stations/{stationId}/reports")
     public ResponseEntity<Void> saveReport(
             @PathVariable String stationId,
             @RequestHeader("Authorization") Long memberId
@@ -27,7 +27,7 @@ public class ReportController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/api/stations/{stationId}/misinformation-reports")
+    @PostMapping("/stations/{stationId}/misinformation-reports")
     public ResponseEntity<Void> saveMisinformationReport(
             @PathVariable String stationId,
             @RequestHeader("Authorization") Long memberId,
@@ -37,7 +37,7 @@ public class ReportController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/api/stations/{stationId}/reports/me")
+    @GetMapping("/stations/{stationId}/reports/me")
     public ResponseEntity<DuplicateReportResponse> isDuplicateReport(
             @PathVariable String stationId,
             @RequestHeader("Authorization") Long memberId

--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
@@ -11,7 +11,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,7 +19,6 @@ import java.util.List;
 import java.util.Set;
 
 @RequiredArgsConstructor
-@RequestMapping("/api")
 @RestController
 public class StationController {
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 server:
   port: 8080
+  servlet:
+    context-path: /api
 
 spring:
   profiles:

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/congestion/CongestionControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/congestion/CongestionControllerTest.java
@@ -49,7 +49,7 @@ class CongestionControllerTest extends MockBeanInjection {
                                 getExpected())
                 );
 
-        mockMvc.perform(get("/api/stations/{stationId}/statistics", stationId))
+        mockMvc.perform(get("/stations/{stationId}/statistics", stationId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.stationId").value("1"))
                 .andDo(customDocument("statistics",

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/report/ReportControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/report/ReportControllerTest.java
@@ -61,7 +61,7 @@ class ReportControllerTest extends MockBeanInjection {
         when(reportService.saveFaultReport(station.getStationId(), memberId)).thenReturn(faultReport);
 
         // then
-        mockMvc.perform(post("/api/stations/{stationId}/reports", station.getStationId())
+        mockMvc.perform(post("/stations/{stationId}/reports", station.getStationId())
                         .header(HttpHeaders.AUTHORIZATION, memberId))
 
                 .andExpect(status().isNoContent())
@@ -88,7 +88,7 @@ class ReportControllerTest extends MockBeanInjection {
         when(reportService.saveMisinformationReport(station.getStationId(), memberId, request)).thenReturn(misinformationReport);
 
         // then
-        mockMvc.perform(post("/api/stations/{stationId}/misinformation-reports", station.getStationId())
+        mockMvc.perform(post("/stations/{stationId}/misinformation-reports", station.getStationId())
                         .header(HttpHeaders.AUTHORIZATION, memberId)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
@@ -116,7 +116,7 @@ class ReportControllerTest extends MockBeanInjection {
         when(reportService.isDuplicateReportStation(memberId, station.getStationId())).thenReturn(false);
 
         // then
-        mockMvc.perform(get("/api/stations/{stationId}/reports/me", station.getStationId())
+        mockMvc.perform(get("/stations/{stationId}/reports/me", station.getStationId())
                         .header(HttpHeaders.AUTHORIZATION, memberId))
 
                 .andExpect(status().isOk())

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
@@ -63,7 +63,7 @@ class StationControllerTest extends MockBeanInjection {
         when(stationService.findByCoordinate(coordinateRequest, List.of("볼튼"), List.of(ChargerType.DC_COMBO), List.of(new BigDecimal("50.00")))).thenReturn(fakeStations);
 
         // then
-        mockMvc.perform(get("/api/stations")
+        mockMvc.perform(get("/stations")
                         .param("latitude", latitude.toString())
                         .param("longitude", longitude.toString())
                         .param("latitudeDelta", latitudeDelta.toString())
@@ -117,7 +117,7 @@ class StationControllerTest extends MockBeanInjection {
         when(stationService.findStationById(stationId)).thenReturn(station);
 
         // then
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/stations/" + stationId))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/" + stationId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.chargers", hasSize(2)))
                 .andDo(customDocument("findChargeStationById",
@@ -153,7 +153,7 @@ class StationControllerTest extends MockBeanInjection {
         when(stationService.findStationById("errorId")).thenThrow(new StationException(StationExceptionType.NOT_FOUND_ID));
 
         // then
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/stations/" + "errorId"))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/" + "errorId"))
                 .andExpect(status().isNotFound())
                 .andDo(customDocument("findChargeStationByInvalidId",
                         responseFields(
@@ -193,7 +193,7 @@ class StationControllerTest extends MockBeanInjection {
                         )
                 ));
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/api/stations/search?q=선릉&page=1&scope=stationName&scope=address&scope=speed&scope=latitude&scope=longitude"))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&page=1&scope=stationName&scope=address&scope=speed&scope=latitude&scope=longitude"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCount").value(2))
                 .andExpect(jsonPath("$.stations", hasSize(2)))

--- a/backend/src/test/java/com/carffeine/carffeine/station/integration/station/StationIntegrationTestFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/integration/station/StationIntegrationTestFixture.java
@@ -24,7 +24,7 @@ public abstract class StationIntegrationTestFixture extends AcceptanceTestFixtur
                 .param("longitude", request.longitude())
                 .param("latitudeDelta", request.latitudeDelta())
                 .param("longitudeDelta", request.longitudeDelta())
-                .get("/api/stations")
+                .get("/stations")
                 .then().log().all()
                 .extract();
     }
@@ -42,7 +42,7 @@ public abstract class StationIntegrationTestFixture extends AcceptanceTestFixtur
 
     public static ExtractableResponse<Response> 충전소_ID로_상세_정보를_조회한다(String 충전소_ID) {
         return RestAssured.given().log().all()
-                .get("/api/stations/{stationId}", 충전소_ID)
+                .get("/stations/{stationId}", 충전소_ID)
                 .then().log().all()
                 .extract();
     }


### PR DESCRIPTION
## 📄 Summary
> 현재 @RequestMapping 혹은 요청 메서드에서 `/api`를 명시해주고 있습니다.
휴먼에러를 방지하기 위해 yml 파일에 prefix로 적용되게 설정했습니다.

## 🕰️ Actual Time of Completion
>

## 🙋🏻 More
> 


close #282