### PR TITLE
fix: request period가 0으로 고정되는 에러를 해결한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/RequestPeriod.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/RequestPeriod.java
@@ -14,7 +14,7 @@ public enum RequestPeriod {
 
     private static final int UNIT = 100;
     private static final List<RequestPeriod> periods = Arrays.stream(values())
-            .sorted(Comparator.comparingInt(RequestPeriod::getSection))
+            .sorted(Comparator.comparingInt(RequestPeriod::getSection).reversed())
             .toList();
 
     private final int section;

--- a/backend/src/test/java/com/carffeine/carffeine/station/domain/congestion/RequestPeriodTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/domain/congestion/RequestPeriodTest.java
@@ -24,6 +24,6 @@ class RequestPeriodTest {
     void TWELVE_구간에_있는지_알수있다(int input) {
         RequestPeriod result = RequestPeriod.from(input);
 
-        assertThat(result).isSameAs(RequestPeriod.ZERO);
+        assertThat(result).isSameAs(RequestPeriod.TWELVE);
     }
 }


### PR DESCRIPTION
[#385]

## 📄 Summary
>  reverse를 했습니다

## 🕰️ Actual Time of Completion
> 5분

## 🙋🏻 More
> 


close #385