### PR TITLE
fix: enum 컨버터로 매핑되지 않는 에러를 해결한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/station/config/RequestPeriodConverter.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/config/RequestPeriodConverter.java
@@ -1,0 +1,18 @@
+package com.carffeine.carffeine.station.config;
+
+import com.carffeine.carffeine.station.domain.congestion.RequestPeriod;
+
+import javax.persistence.AttributeConverter;
+
+public class RequestPeriodConverter implements AttributeConverter<RequestPeriod, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(RequestPeriod attribute) {
+        return attribute.getSection();
+    }
+
+    @Override
+    public RequestPeriod convertToEntityAttribute(Integer dbData) {
+        return RequestPeriod.from(dbData);
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestion.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestion.java
@@ -1,5 +1,6 @@
 package com.carffeine.carffeine.station.domain.congestion;
 
+import com.carffeine.carffeine.station.config.RequestPeriodConverter;
 import com.carffeine.carffeine.station.domain.charger.Charger;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.ConstraintMode;
+import javax.persistence.Convert;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
@@ -31,6 +33,7 @@ public class PeriodicCongestion {
 
     @Enumerated(EnumType.STRING)
     private DayOfWeek dayOfWeek;
+    @Convert(converter = RequestPeriodConverter.class)
     private RequestPeriod startTime;
     private int useCount;
     private int totalCount;


### PR DESCRIPTION
[#391]

## 📄 Summary
> enum의 값 0이 section의 value인줄 알고 코드를 작성했습니다. 하지만 알고봤더니 ordinal이였습니다. 그래서 이 부분이 매핑되지 않아서 에러가 발생합니다. 만약 이 부분을 해결하려면 table을 새로 drop하던지, 혹은 section으로 저장되어 있는 값들을 전부 update 쿼리를 사용해서 변경해야할 것입니다. 하지만 converter를 사용해서 변경하는 방법도 있고, enum의 ordinal이나 name에 의존하지 않는 것도 좋은 것 같아 이러한 식으로 변경했습니다. 

## 🕰️ Actual Time of Completion
> 30분

## 🙋🏻 More
> https://techblog.woowahan.com/2600/


close #391