### PR TITLE
fix: 충전소 검색기를 통해 이동 시, 줌 조절이 안되고 InfoWindow가 동작하지 않는 문제를 수정한다

### DIFF
--- a/frontend/src/components/ui/StationSearchWindow/SearchResult.stories.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/SearchResult.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta } from '@storybook/react';
 import { styled } from 'styled-components';
 
+import SearchResultSkeleton from '@ui/StationSearchWindow/SearchResultSkeleton';
+
 import type { SearchResultProps } from './SearchResult';
 import SearchResult from './SearchResult';
 
@@ -12,6 +14,14 @@ const meta = {
       {
         stationId: '0',
         stationName: '충전소 이름이라네',
+        speed: 'quick',
+        address: '서울시 강남구 테헤란로 411',
+        latitude: 1,
+        longitude: 1,
+      },
+      {
+        stationId: '1',
+        stationName: '허허',
         speed: 'quick',
         address: '서울시 강남구 테헤란로 411',
         latitude: 1,
@@ -35,6 +45,15 @@ export const Default = ({ ...args }: SearchResultProps) => {
   return (
     <S.Container>
       <SearchResult {...args} />
+    </S.Container>
+  );
+};
+
+export const Skeleton = ({ ...args }: SearchResultProps) => {
+  return (
+    <S.Container>
+      <SearchResult {...args} />
+      <SearchResultSkeleton />
     </S.Container>
   );
 };

--- a/frontend/src/components/ui/StationSearchWindow/SearchResultSkeleton.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/SearchResultSkeleton.tsx
@@ -1,0 +1,27 @@
+import Box from '@common/Box';
+import List from '@common/List';
+import ListItem from '@common/ListItem';
+import Skeleton from '@common/Skeleton';
+
+import { foundStationList, searchResultList } from '@ui/StationSearchWindow/SearchResult';
+
+const SearchResultSkeleton = () => {
+  return (
+    <List css={searchResultList}>
+      {Array.from({ length: 10 }, (_, index) => (
+        <ListItem divider NoLastDivider key={index} css={foundStationList}>
+          <Box p={2}>
+            <Box mb={2}>
+              <Skeleton width="12rem" height="1.2rem" />
+            </Box>
+            <Box>
+              <Skeleton width="24rem" />
+            </Box>
+          </Box>
+        </ListItem>
+      ))}
+    </List>
+  );
+};
+
+export default SearchResultSkeleton;

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -18,6 +18,7 @@ import { useDebounce } from '@hooks/useDebounce';
 import Button from '@common/Button';
 
 import StationDetailsWindow from '@ui/StationDetailsWindow';
+import SearchResultSkeleton from '@ui/StationSearchWindow/SearchResultSkeleton';
 import { useNavigationBar } from '@ui/compound/NavigationBar/hooks/useNavigationBar';
 
 import { pillStyle } from '@style';
@@ -27,7 +28,7 @@ import { QUERY_KEY_STATIONS } from '@constants/queryKeys';
 
 import type { StationPosition } from '@type/stations';
 
-import SearchResult from './SearchResult';
+import SearchResult, { foundStationList, searchResultList } from './SearchResult';
 
 const StationSearchBar = () => {
   const [isFocused, setIsFocused] = useState(false);
@@ -48,7 +49,7 @@ const StationSearchBar = () => {
     400
   );
 
-  const { data: stations, isLoading, isError } = useSearchedStations();
+  const { data: stations, isLoading, isError, isFetching } = useSearchedStations();
 
   const handleSubmitSearchWord = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -92,6 +93,7 @@ const StationSearchBar = () => {
           <MagnifyingGlassIcon width="2.4rem" stroke="#767676" />
         </Button>
       </S.Form>
+      {isFetching && <SearchResultSkeleton />}
       {isFocused && stations && (
         <SearchResult
           stations={stations}

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -22,6 +22,7 @@ import { useNavigationBar } from '@ui/compound/NavigationBar/hooks/useNavigation
 
 import { pillStyle } from '@style';
 
+import { INITIAL_ZOOM_SIZE } from '@constants/googleMaps';
 import { QUERY_KEY_STATIONS } from '@constants/queryKeys';
 
 import type { StationPosition } from '@type/stations';
@@ -62,6 +63,8 @@ const StationSearchBar = () => {
 
   const showStationDetails = ({ stationId, latitude, longitude }: StationPosition) => {
     googleMap.panTo({ lat: latitude, lng: longitude });
+    googleMap.setZoom(INITIAL_ZOOM_SIZE);
+
     queryClient.invalidateQueries({ queryKey: [QUERY_KEY_STATIONS] });
     setSelectedStationId(stationId);
     openLastPanel(<StationDetailsWindow />);

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -28,7 +28,7 @@ import { QUERY_KEY_STATIONS } from '@constants/queryKeys';
 
 import type { StationPosition } from '@type/stations';
 
-import SearchResult, { foundStationList, searchResultList } from './SearchResult';
+import SearchResult from './SearchResult';
 
 const StationSearchBar = () => {
   const [isFocused, setIsFocused] = useState(false);

--- a/frontend/src/hooks/google-maps/useGoogleMap.tsx
+++ b/frontend/src/hooks/google-maps/useGoogleMap.tsx
@@ -7,19 +7,21 @@ import { getGoogleMapStore } from '@stores/google-maps/googleMapStore';
 import { markerInstanceStore } from '@stores/google-maps/markerInstanceStore';
 import { selectedStationIdStore } from '@stores/selectedStationStore';
 
+import StationDetailsWindow from '@ui/StationDetailsWindow';
+import { useNavigationBar } from '@ui/compound/NavigationBar/hooks/useNavigationBar';
+
 import type { StationSummary } from '@type';
 
 import BlueMarker from '@assets/blue-marker.svg';
 
 import { useStationSummary } from './useStationSummary';
-import { useNavigationBar } from '@ui/compound/NavigationBar/hooks/useNavigationBar';
-import StationDetailsWindow from '@ui/StationDetailsWindow';
 
 export const useGoogleMap = () => {
   const googleMap = useExternalValue(getGoogleMapStore());
   const setMarkerInstanceState = useSetExternalState(markerInstanceStore);
   const setSelectedStationId = useSetExternalState(selectedStationIdStore);
-  
+  const selectedStationId = getStoreSnapshot(selectedStationIdStore);
+
   const { openLastPanel } = useNavigationBar();
   const { openStationSummary } = useStationSummary();
 
@@ -49,6 +51,10 @@ export const useGoogleMap = () => {
         markerInstance,
       },
     ]);
+
+    if (selectedStationId === stationId) {
+      openStationSummary(station, markerInstance);
+    }
 
     return () => {
       const selectedStationId = getStoreSnapshot(selectedStationIdStore);


### PR DESCRIPTION
## 📄 Summary
> 충전소 검색기를 개편했습니다.
충전소 검색 결과를 클릭했을 때 줌을 15로 고정합니다.
추가로 마커가 클릭 된 효과와 동일하게 InfoWindow를 띄웁니다.
충전소 검색 시 스켈레톤을 추가하였습니다.

## 🕰️ Actual Time of Completion
> 2시간

## 🙋🏻 More
> 


close #438