### PR TITLE
feat: 차량 관리 기능과, 유저의 차량을 등록할 수 있는 기능을 구현한다

### DIFF
--- a/backend/src/docs/asciidoc/car.adoc
+++ b/backend/src/docs/asciidoc/car.adoc
@@ -35,7 +35,34 @@ include::{snippets}/car-controller-test/save_all_cars/http-response.adoc[]
 
 include::{snippets}/car-controller-test/delete_car/request-headers.adoc[]
 include::{snippets}/car-controller-test/delete_car/path-parameters.adoc[]
+include::{snippets}/car-controller-test/delete_car/http-request.adoc[]
 
 === Response
 
 include::{snippets}/car-controller-test/delete_car/http-response.adoc[]
+
+== 차량에 등록된 필터를 조회한다 (/cars/{carId}/filters)
+
+=== Request
+
+include::{snippets}/car-controller-test/find_car_filters/path-parameters.adoc[]
+include::{snippets}/car-controller-test/find_car_filters/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/car-controller-test/find_car_filters/response-fields.adoc[]
+include::{snippets}/car-controller-test/find_car_filters/http-response.adoc[]
+
+== 차량에 필터를 등록한다 (/cars/{carId}/filters)
+
+=== Request
+
+include::{snippets}/car-controller-test/add_car_filters/request-headers.adoc[]
+include::{snippets}/car-controller-test/add_car_filters/path-parameters.adoc[]
+include::{snippets}/car-controller-test/add_car_filters/request-body.adoc[]
+include::{snippets}/car-controller-test/add_car_filters/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/car-controller-test/add_car_filters/response-fields.adoc[]
+include::{snippets}/car-controller-test/add_car_filters/http-response.adoc[]

--- a/backend/src/docs/asciidoc/car.adoc
+++ b/backend/src/docs/asciidoc/car.adoc
@@ -1,0 +1,41 @@
+= Filter API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+
+== 차량을 모두 조회한다 (/cars)
+
+=== Request
+
+include::{snippets}/car-controller-test/find_all_cars/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/car-controller-test/find_all_cars/response-fields.adoc[]
+include::{snippets}/car-controller-test/find_all_cars/http-response.adoc[]
+
+== 차량을 등록한다 (/cars)
+
+=== Request
+
+include::{snippets}/car-controller-test/save_all_cars/request-headers.adoc[]
+include::{snippets}/car-controller-test/save_all_cars/request-fields.adoc[]
+include::{snippets}/car-controller-test/save_all_cars/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/car-controller-test/save_all_cars/response-fields.adoc[]
+include::{snippets}/car-controller-test/save_all_cars/http-response.adoc[]
+
+== 차량을 제거한다 (/cars/{carId})
+
+=== Request
+
+include::{snippets}/car-controller-test/delete_car/request-headers.adoc[]
+include::{snippets}/car-controller-test/delete_car/path-parameters.adoc[]
+
+=== Response
+
+include::{snippets}/car-controller-test/delete_car/http-response.adoc[]

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -9,3 +9,4 @@ endif::[]
 
 include::station.adoc[]
 include::filter.adoc[]
+include::car.adoc[]

--- a/backend/src/docs/asciidoc/member.adoc
+++ b/backend/src/docs/asciidoc/member.adoc
@@ -33,3 +33,28 @@ include::{snippets}/member-controller-test/add_member_filters/http-request.adoc[
 include::{snippets}/member-controller-test/add_member_filters/response-fields.adoc[]
 include::{snippets}/member-controller-test/add_member_filters/http-response.adoc[]
 
+== 회원이 등록한 차량을 조회한다
+
+=== Request
+
+include::{snippets}/member-controller-test/find_member_car/request-headers.adoc[]
+include::{snippets}/member-controller-test/find_member_car/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/member-controller-test/find_member_car/response-fields.adoc[]
+include::{snippets}/member-controller-test/find_member_car/http-response.adoc[]
+
+== 회원이 차량을 등록한다
+
+=== Request
+
+include::{snippets}/member-controller-test/add_member_car/request-headers.adoc[]
+include::{snippets}/member-controller-test/add_member_car/path-parameters.adoc[]
+include::{snippets}/member-controller-test/add_member_car/request-fields.adoc[]
+include::{snippets}/member-controller-test/add_member_car/http-request.adoc[]
+
+=== Response
+
+include::{snippets}/member-controller-test/add_member_car/response-fields.adoc[]
+include::{snippets}/member-controller-test/add_member_car/http-response.adoc[]

--- a/backend/src/main/java/com/carffeine/carffeine/car/controller/CarController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/controller/CarController.java
@@ -1,0 +1,48 @@
+package com.carffeine.carffeine.car.controller;
+
+import com.carffeine.carffeine.auth.controller.AuthMember;
+import com.carffeine.carffeine.car.controller.dto.CarsResponse;
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.service.CarService;
+import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/cars")
+@RestController
+public class CarController {
+
+    private final CarService carService;
+
+    @GetMapping
+    public ResponseEntity<CarsResponse> findAllCars() {
+        List<Car> cars = carService.findAllCars();
+        return ResponseEntity.ok(CarsResponse.from(cars));
+    }
+
+    @PostMapping
+    public ResponseEntity<CarsResponse> saveAllCars(@AuthMember Long memberId,
+                                                    @RequestBody CarsRequest carsRequest) {
+        List<Car> cars = carService.saveCars(memberId, carsRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CarsResponse.from(cars));
+    }
+
+    @DeleteMapping("/{carId}")
+    public ResponseEntity<Void> deleteCarById(@AuthMember Long memberId,
+                                              @PathVariable Long carId) {
+        carService.deleteCar(memberId, carId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/controller/CarController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/controller/CarController.java
@@ -5,6 +5,9 @@ import com.carffeine.carffeine.car.controller.dto.CarsResponse;
 import com.carffeine.carffeine.car.domain.Car;
 import com.carffeine.carffeine.car.service.CarService;
 import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.filter.controller.dto.FiltersResponse;
+import com.carffeine.carffeine.filter.domain.Filter;
+import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -44,5 +47,20 @@ public class CarController {
                                               @PathVariable Long carId) {
         carService.deleteCar(memberId, carId);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{carId}/filters")
+    public ResponseEntity<FiltersResponse> findCarFilters(@PathVariable Long carId) {
+        List<Filter> filters = carService.findCarFilters(carId);
+        return ResponseEntity.ok(FiltersResponse.from(filters));
+    }
+
+    @PostMapping("/{carId}/filters")
+    public ResponseEntity<FiltersResponse> addCarFilters(@AuthMember Long memberId,
+                                                         @PathVariable Long carId,
+                                                         @RequestBody FiltersRequest filtersRequest) {
+        List<Filter> filters = carService.addCarFilters(memberId, carId, filtersRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(FiltersResponse.from(filters));
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/car/controller/dto/CarResponse.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/controller/dto/CarResponse.java
@@ -1,0 +1,18 @@
+package com.carffeine.carffeine.car.controller.dto;
+
+import com.carffeine.carffeine.car.domain.Car;
+
+public record CarResponse(
+        Long carId,
+        String name,
+        String vintage
+) {
+
+    public static CarResponse from(Car car) {
+        return new CarResponse(
+                car.getId(),
+                car.getName(),
+                car.getVintage()
+        );
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/controller/dto/CarsResponse.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/controller/dto/CarsResponse.java
@@ -1,0 +1,16 @@
+package com.carffeine.carffeine.car.controller.dto;
+
+import com.carffeine.carffeine.car.domain.Car;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record CarsResponse(List<CarResponse> cars) {
+
+    public static CarsResponse from(List<Car> cars) {
+        return cars.stream()
+                .map(CarResponse::from)
+                .collect(Collectors.collectingAndThen(Collectors.toList(), CarsResponse::new));
+
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/domain/Car.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/domain/Car.java
@@ -8,6 +8,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -27,8 +28,10 @@ public class Car extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false, length = 64)
     private String name;
 
+    @Column(nullable = false, length = 64)
     private String vintage;
 
     private Car(String name, String vintage) {

--- a/backend/src/main/java/com/carffeine/carffeine/car/domain/Car.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/domain/Car.java
@@ -1,0 +1,42 @@
+package com.carffeine.carffeine.car.domain;
+
+import com.carffeine.carffeine.common.domain.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@Table(name = "car")
+@Entity
+public class Car extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    private String vintage;
+
+    private Car(String name, String vintage) {
+        this.name = name;
+        this.vintage = vintage;
+    }
+
+    public static Car from(String name, String vintage) {
+        return new Car(name, vintage);
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/domain/CarFilter.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/domain/CarFilter.java
@@ -1,0 +1,49 @@
+package com.carffeine.carffeine.car.domain;
+
+import com.carffeine.carffeine.common.domain.BaseEntity;
+import com.carffeine.carffeine.filter.domain.Filter;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@Table(name = "car_filter")
+@Entity
+public class CarFilter extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "car_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Car car;
+
+    @ManyToOne
+    @JoinColumn(name = "filter_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Filter filter;
+
+    public CarFilter(Car car, Filter filter) {
+        this.car = car;
+        this.filter = filter;
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/domain/CarFilterRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/domain/CarFilterRepository.java
@@ -1,0 +1,14 @@
+package com.carffeine.carffeine.car.domain;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+
+public interface CarFilterRepository extends Repository<CarFilter, Long> {
+
+    List<CarFilter> findAllByCar(Car car);
+
+    <S extends CarFilter> List<S> saveAll(Iterable<S> carFilters);
+
+    void deleteAllByCar(Car car);
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/domain/CarRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/domain/CarRepository.java
@@ -9,6 +9,8 @@ public interface CarRepository extends Repository<Car, Long> {
 
     Optional<Car> findById(Long carId);
 
+    Optional<Car> findByNameAndVintage(String name, String vintage);
+
     List<Car> findAll();
 
     boolean existsByNameAndVintage(String name, String vintage);

--- a/backend/src/main/java/com/carffeine/carffeine/car/domain/CarRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/domain/CarRepository.java
@@ -1,0 +1,19 @@
+package com.carffeine.carffeine.car.domain;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface CarRepository extends Repository<Car, Long> {
+
+    Optional<Car> findById(Long carId);
+
+    List<Car> findAll();
+
+    boolean existsByNameAndVintage(String name, String vintage);
+
+    Car save(Car car);
+
+    void deleteById(Long id);
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/exception/CarException.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/exception/CarException.java
@@ -1,0 +1,11 @@
+package com.carffeine.carffeine.car.exception;
+
+import com.carffeine.carffeine.common.exception.BaseException;
+import com.carffeine.carffeine.common.exception.ExceptionType;
+
+public class CarException extends BaseException {
+
+    public CarException(ExceptionType exceptionType) {
+        super(exceptionType);
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/exception/CarExceptionType.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/exception/CarExceptionType.java
@@ -5,7 +5,7 @@ import com.carffeine.carffeine.common.exception.Status;
 
 public enum CarExceptionType implements ExceptionType {
 
-    NOT_FOUND_EXCEPTION(Status.NOT_FOUND, 1001, "해당 차량을 찾을 수 없습니다.");
+    NOT_FOUND_EXCEPTION(Status.NOT_FOUND, 5001, "해당 차량을 찾을 수 없습니다.");
 
     private final Status status;
     private final int exceptionCode;

--- a/backend/src/main/java/com/carffeine/carffeine/car/exception/CarExceptionType.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/exception/CarExceptionType.java
@@ -1,0 +1,34 @@
+package com.carffeine.carffeine.car.exception;
+
+import com.carffeine.carffeine.common.exception.ExceptionType;
+import com.carffeine.carffeine.common.exception.Status;
+
+public enum CarExceptionType implements ExceptionType {
+
+    NOT_FOUND_EXCEPTION(Status.NOT_FOUND, 1001, "해당 차량을 찾을 수 없습니다.");
+
+    private final Status status;
+    private final int exceptionCode;
+    private final String message;
+
+    CarExceptionType(Status status, int exceptionCode, String message) {
+        this.status = status;
+        this.exceptionCode = exceptionCode;
+        this.message = message;
+    }
+
+    @Override
+    public Status status() {
+        return status;
+    }
+
+    @Override
+    public int exceptionCode() {
+        return exceptionCode;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
@@ -3,10 +3,17 @@ package com.carffeine.carffeine.car.service;
 import com.carffeine.carffeine.admin.exception.AdminException;
 import com.carffeine.carffeine.admin.exception.AdminExceptionType;
 import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarFilter;
+import com.carffeine.carffeine.car.domain.CarFilterRepository;
 import com.carffeine.carffeine.car.domain.CarRepository;
 import com.carffeine.carffeine.car.exception.CarException;
 import com.carffeine.carffeine.car.service.dto.CarRequest;
 import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.filter.domain.Filter;
+import com.carffeine.carffeine.filter.domain.FilterRepository;
+import com.carffeine.carffeine.filter.exception.FilterException;
+import com.carffeine.carffeine.filter.exception.FilterExceptionType;
+import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
 import com.carffeine.carffeine.member.domain.Member;
 import com.carffeine.carffeine.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +31,8 @@ public class CarService {
 
     private final MemberRepository memberRepository;
     private final CarRepository carRepository;
+    private final CarFilterRepository carFilterRepository;
+    private final FilterRepository filterRepository;
 
     @Transactional(readOnly = true)
     public List<Car> findAllCars() {
@@ -61,8 +70,54 @@ public class CarService {
         carRepository.deleteById(car.getId());
     }
 
+    @Transactional(readOnly = true)
+    public List<Filter> findCarFilters(Long carId) {
+        Car car = findCar(carId);
+        return findAllFiltersByCar(car);
+    }
+
     private Car findCar(Long carId) {
         return carRepository.findById(carId)
                 .orElseThrow(() -> new CarException(NOT_FOUND_EXCEPTION));
+    }
+
+    private List<Filter> findAllFiltersByCar(Car car) {
+        return carFilterRepository.findAllByCar(car)
+                .stream()
+                .map(CarFilter::getFilter)
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public List<Filter> addCarFilters(Long memberId,
+                                      Long carId,
+                                      FiltersRequest filtersRequest) {
+        validateRole(memberId);
+        Car car = findCar(carId);
+        carFilterRepository.deleteAllByCar(car);
+        return makeCarFilters(filtersRequest, car);
+    }
+
+    private void validateRole(Long memberId) {
+        memberRepository.findById(memberId)
+                .filter(Member::isAdmin)
+                .orElseThrow(() -> new AdminException(AdminExceptionType.NOT_ADMIN));
+    }
+
+    private List<Filter> makeCarFilters(FiltersRequest filtersRequest, Car car) {
+        List<Filter> filters = filtersRequest.filters()
+                .stream()
+                .map(it -> filterRepository.findByName(it.name())
+                        .orElseThrow(() -> new FilterException(FilterExceptionType.FILTER_NOT_FOUND)))
+                .toList();
+
+        List<CarFilter> carFilters = filters.stream()
+                .map(it -> new CarFilter(car, it))
+                .toList();
+
+        return carFilterRepository.saveAll(carFilters)
+                .stream()
+                .map(CarFilter::getFilter)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
@@ -66,8 +66,7 @@ public class CarService {
     @Transactional
     public void deleteCar(Long memberId, Long carId) {
         validateIsMemberAdmin(memberId);
-        Car car = findCar(carId);
-        carRepository.deleteById(car.getId());
+        carRepository.deleteById(carId);
     }
 
     @Transactional(readOnly = true)
@@ -107,8 +106,7 @@ public class CarService {
     private List<Filter> makeCarFilters(FiltersRequest filtersRequest, Car car) {
         List<Filter> filters = filtersRequest.filters()
                 .stream()
-                .map(it -> filterRepository.findByName(it.name())
-                        .orElseThrow(() -> new FilterException(FilterExceptionType.FILTER_NOT_FOUND)))
+                .map(it -> findFilter(it.name()))
                 .toList();
 
         List<CarFilter> carFilters = filters.stream()
@@ -119,5 +117,10 @@ public class CarService {
                 .stream()
                 .map(CarFilter::getFilter)
                 .toList();
+    }
+
+    private Filter findFilter(String filterName) {
+        return filterRepository.findByName(filterName)
+                .orElseThrow(() -> new FilterException(FilterExceptionType.FILTER_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
@@ -21,9 +21,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static com.carffeine.carffeine.car.exception.CarExceptionType.NOT_FOUND_EXCEPTION;
+import static java.util.stream.Collectors.toList;
 
 @RequiredArgsConstructor
 @Service
@@ -56,7 +56,7 @@ public class CarService {
                 .stream()
                 .filter(it -> !isAlreadyExisted(it))
                 .map(it -> carRepository.save(Car.from(it.name(), it.vintage())))
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     private boolean isAlreadyExisted(CarRequest carRequest) {
@@ -85,7 +85,7 @@ public class CarService {
         return carFilterRepository.findAllByCar(car)
                 .stream()
                 .map(CarFilter::getFilter)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     @Transactional

--- a/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/service/CarService.java
@@ -1,0 +1,68 @@
+package com.carffeine.carffeine.car.service;
+
+import com.carffeine.carffeine.admin.exception.AdminException;
+import com.carffeine.carffeine.admin.exception.AdminExceptionType;
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarRepository;
+import com.carffeine.carffeine.car.exception.CarException;
+import com.carffeine.carffeine.car.service.dto.CarRequest;
+import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.member.domain.Member;
+import com.carffeine.carffeine.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.carffeine.carffeine.car.exception.CarExceptionType.NOT_FOUND_EXCEPTION;
+
+@RequiredArgsConstructor
+@Service
+public class CarService {
+
+    private final MemberRepository memberRepository;
+    private final CarRepository carRepository;
+
+    @Transactional(readOnly = true)
+    public List<Car> findAllCars() {
+        return carRepository.findAll();
+    }
+
+    @Transactional
+    public List<Car> saveCars(Long memberId, CarsRequest carsRequest) {
+        validateIsMemberAdmin(memberId);
+        return saveAll(carsRequest);
+    }
+
+    private void validateIsMemberAdmin(Long memberId) {
+        memberRepository.findById(memberId)
+                .filter(Member::isAdmin)
+                .orElseThrow(() -> new AdminException(AdminExceptionType.NOT_ADMIN));
+    }
+
+    private List<Car> saveAll(CarsRequest carsRequest) {
+        return carsRequest.cars()
+                .stream()
+                .filter(it -> !isAlreadyExisted(it))
+                .map(it -> carRepository.save(Car.from(it.name(), it.vintage())))
+                .collect(Collectors.toList());
+    }
+
+    private boolean isAlreadyExisted(CarRequest carRequest) {
+        return carRepository.existsByNameAndVintage(carRequest.name(), carRequest.vintage());
+    }
+
+    @Transactional
+    public void deleteCar(Long memberId, Long carId) {
+        validateIsMemberAdmin(memberId);
+        Car car = findCar(carId);
+        carRepository.deleteById(car.getId());
+    }
+
+    private Car findCar(Long carId) {
+        return carRepository.findById(carId)
+                .orElseThrow(() -> new CarException(NOT_FOUND_EXCEPTION));
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/service/dto/CarRequest.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/service/dto/CarRequest.java
@@ -1,0 +1,7 @@
+package com.carffeine.carffeine.car.service.dto;
+
+public record CarRequest(
+        String name,
+        String vintage
+) {
+}

--- a/backend/src/main/java/com/carffeine/carffeine/car/service/dto/CarsRequest.java
+++ b/backend/src/main/java/com/carffeine/carffeine/car/service/dto/CarsRequest.java
@@ -1,0 +1,6 @@
+package com.carffeine.carffeine.car.service.dto;
+
+import java.util.List;
+
+public record CarsRequest(List<CarRequest> cars) {
+}

--- a/backend/src/main/java/com/carffeine/carffeine/member/controller/MemberController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/controller/MemberController.java
@@ -1,12 +1,18 @@
 package com.carffeine.carffeine.member.controller;
 
 import com.carffeine.carffeine.auth.controller.AuthMember;
+import com.carffeine.carffeine.car.controller.dto.CarResponse;
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.service.dto.CarRequest;
 import com.carffeine.carffeine.filter.controller.dto.FiltersResponse;
 import com.carffeine.carffeine.filter.domain.Filter;
 import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
+import com.carffeine.carffeine.member.controller.dto.MemberCarInfoResponse;
+import com.carffeine.carffeine.member.domain.MemberCar;
 import com.carffeine.carffeine.member.domain.MemberFilter;
 import com.carffeine.carffeine.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -37,5 +43,20 @@ public class MemberController {
                                                             @RequestBody FiltersRequest filtersRequest) {
         List<MemberFilter> memberFilters = memberService.addMemberFilters(memberId, loginMember, filtersRequest);
         return ResponseEntity.ok(FiltersResponse.fromMemberFilters(memberFilters));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<MemberCarInfoResponse> findMemberCarInfo(@AuthMember Long loginMember) {
+        MemberCar memberCar = memberService.findMemberCar(loginMember);
+        return ResponseEntity.ok(MemberCarInfoResponse.from(memberCar));
+    }
+
+    @PostMapping("/{memberId}/cars")
+    public ResponseEntity<CarResponse> addMemberCar(@PathVariable Long memberId,
+                                                    @AuthMember Long loginMember,
+                                                    @RequestBody CarRequest carRequest) {
+        Car car = memberService.addMemberCar(memberId, loginMember, carRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(CarResponse.from(car));
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/member/controller/dto/MemberCarInfoResponse.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/controller/dto/MemberCarInfoResponse.java
@@ -3,8 +3,9 @@ package com.carffeine.carffeine.member.controller.dto;
 import com.carffeine.carffeine.car.controller.dto.CarResponse;
 import com.carffeine.carffeine.member.domain.MemberCar;
 
-public record MemberCarInfoResponse(Long memberId,
-                                    CarResponse car
+public record MemberCarInfoResponse(
+        Long memberId,
+        CarResponse car
 ) {
 
     public static MemberCarInfoResponse from(MemberCar memberCar) {

--- a/backend/src/main/java/com/carffeine/carffeine/member/controller/dto/MemberCarInfoResponse.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/controller/dto/MemberCarInfoResponse.java
@@ -1,0 +1,13 @@
+package com.carffeine.carffeine.member.controller.dto;
+
+import com.carffeine.carffeine.car.controller.dto.CarResponse;
+import com.carffeine.carffeine.member.domain.MemberCar;
+
+public record MemberCarInfoResponse(Long memberId,
+                                    CarResponse car
+) {
+
+    public static MemberCarInfoResponse from(MemberCar memberCar) {
+        return new MemberCarInfoResponse(memberCar.getMember().getId(), CarResponse.from(memberCar.getCar()));
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCar.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCar.java
@@ -16,7 +16,6 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
@@ -33,7 +32,7 @@ public class MemberCar extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "member_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;

--- a/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCar.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCar.java
@@ -1,0 +1,48 @@
+package com.carffeine.carffeine.member.domain;
+
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.common.domain.BaseEntity;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member_car")
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
+@Entity
+public class MemberCar extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "car_id", nullable = false)
+    private Car car;
+
+    public MemberCar(Member member, Car car) {
+        this.member = member;
+        this.car = car;
+    }
+}

--- a/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCar.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCar.java
@@ -17,6 +17,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
 @Getter
@@ -37,7 +38,7 @@ public class MemberCar extends BaseEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "car_id", nullable = false)
     private Car car;
 

--- a/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCarRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/domain/MemberCarRepository.java
@@ -1,0 +1,14 @@
+package com.carffeine.carffeine.member.domain;
+
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface MemberCarRepository extends Repository<MemberCar, Long> {
+
+    Optional<MemberCar> findByMember(Member member);
+
+    MemberCar save(MemberCar memberCar);
+
+    void deleteByMember(Member member);
+}

--- a/backend/src/main/java/com/carffeine/carffeine/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/exception/MemberExceptionType.java
@@ -7,7 +7,8 @@ public enum MemberExceptionType implements ExceptionType {
 
     NOT_FOUND(Status.NOT_FOUND, 3001, "회원이 없습니다"),
     NOT_FOUND_ROLE(Status.NOT_FOUND, 3002, "일치하는 권한이 없습니다"),
-    INVALID_ACCESS(Status.INVALID, 3003, "본인의 계정이 아닙니다");
+    INVALID_ACCESS(Status.INVALID, 3003, "본인의 계정이 아닙니다"),
+    CAR_NOT_FOUND(Status.NOT_FOUND, 3004, "해당 유저의 차량을 찾을 수 없습니다");
 
     private final Status status;
     private final int exceptionCode;

--- a/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
@@ -3,6 +3,10 @@ package com.carffeine.carffeine.car.controller;
 import com.carffeine.carffeine.car.domain.Car;
 import com.carffeine.carffeine.car.service.dto.CarRequest;
 import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.filter.domain.Filter;
+import com.carffeine.carffeine.filter.domain.FilterType;
+import com.carffeine.carffeine.filter.service.dto.FilterRequest;
+import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
 import com.carffeine.carffeine.helper.MockBeanInjection;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.http.HttpHeaders;
@@ -20,21 +24,25 @@ import java.util.List;
 
 import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
 import static com.carffeine.carffeine.car.fixture.CarFixture.createOtherCar;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createCapacityFilter;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createCompanyFilter;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createConnectorTypeFilter;
 import static com.carffeine.carffeine.helper.RestDocsHelper.customDocument;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -120,10 +128,79 @@ class CarControllerTest extends MockBeanInjection {
         mockMvc.perform(delete("/cars/{carId}", 1L)
                         .header(HttpHeaders.AUTHORIZATION, "token")
                 ).andExpect(status().isNoContent())
-                .andDo(customDocument("save_all_cars",
+                .andDo(customDocument("delete_car",
                         requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
-                        pathParameters(
-                                parameterWithName("carId").description("차량 id")
+                        pathParameters(parameterWithName("carId").description("차량 id"))
+                ));
+    }
+
+    @Test
+    void 차량_필터를_모두_조회한다() throws Exception {
+        // given
+        List<Filter> filters = List.of(
+                createCompanyFilter(),
+                createConnectorTypeFilter(),
+                createCapacityFilter()
+        );
+
+        // when
+        when(carService.findCarFilters(anyLong())).thenReturn(filters);
+
+        // then
+        mockMvc.perform(get("/cars/{carId}/filters", 1L))
+                .andExpect(status().isOk())
+                .andDo(customDocument("find_car_filters",
+                        pathParameters(parameterWithName("carId").description("차량 id")),
+                        responseFields(
+                                fieldWithPath("companies[0]").type(JsonFieldType.ARRAY).description("충전기 회사"),
+                                fieldWithPath("capacities[0]").type(JsonFieldType.ARRAY).description("충전 용량"),
+                                fieldWithPath("connectorTypes[0]").type(JsonFieldType.ARRAY).description("충전기 타입")
+                        )
+                ));
+    }
+
+    @Test
+    void 차량_필터를_저장한다() throws Exception {
+        // given
+        List<Filter> filters = List.of(
+                createCompanyFilter(),
+                createConnectorTypeFilter(),
+                createCapacityFilter()
+        );
+
+        FiltersRequest request = new FiltersRequest(
+                List.of(
+                        new FilterRequest(FilterType.COMPANY.getName(), "HG"),
+                        new FilterRequest(FilterType.CAPACITY.getName(), "2.00"),
+                        new FilterRequest(FilterType.CONNECTOR_TYPE.getName(), "DC_COMBO")
+                )
+        );
+
+        // when
+        when(carService.addCarFilters(anyLong(), anyLong(), any())).thenReturn(filters);
+
+        // then
+        mockMvc.perform(post("/cars/{carId}/filters", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                )
+                .andExpect(status().isCreated())
+                .andDo(customDocument("add_car_filters",
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
+                        pathParameters(parameterWithName("carId").description("차량 id")),
+                        requestFields(
+                                fieldWithPath("filters[0].type").type(JsonFieldType.STRING).description("필터 종류"),
+                                fieldWithPath("filters[0].name").type(JsonFieldType.STRING).description("필터 이름"),
+                                fieldWithPath("filters[1].type").type(JsonFieldType.STRING).description("필터 종류"),
+                                fieldWithPath("filters[1].name").type(JsonFieldType.STRING).description("필터 이름"),
+                                fieldWithPath("filters[2].type").type(JsonFieldType.STRING).description("필터 종류"),
+                                fieldWithPath("filters[2].name").type(JsonFieldType.STRING).description("필터 이름")
+                        ),
+                        responseFields(
+                                fieldWithPath("companies[0]").type(JsonFieldType.ARRAY).description("충전기 회사"),
+                                fieldWithPath("capacities[0]").type(JsonFieldType.ARRAY).description("충전 용량"),
+                                fieldWithPath("connectorTypes[0]").type(JsonFieldType.ARRAY).description("충전기 타입")
                         )
                 ));
     }

--- a/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
@@ -1,0 +1,130 @@
+package com.carffeine.carffeine.car.controller;
+
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.service.dto.CarRequest;
+import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.helper.MockBeanInjection;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
+import static com.carffeine.carffeine.car.fixture.CarFixture.createOtherCar;
+import static com.carffeine.carffeine.helper.RestDocsHelper.customDocument;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@AutoConfigureRestDocs
+@WebMvcTest(CarController.class)
+class CarControllerTest extends MockBeanInjection {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void 모든_차량_정보를_조회한다() throws Exception {
+        // given
+        List<Car> cars = List.of(createCar(), createOtherCar());
+
+        // when
+        when(carService.findAllCars()).thenReturn(cars);
+
+        // then
+        mockMvc.perform(get("/cars"))
+                .andExpect(status().isOk())
+                .andDo(customDocument("find_all_cars",
+                        responseFields(
+                                fieldWithPath("cars[0].carId").type(JsonFieldType.NUMBER).description("차량의 id"),
+                                fieldWithPath("cars[0].name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("cars[0].vintage").type(JsonFieldType.STRING).description("차량 연식"),
+                                fieldWithPath("cars[1].carId").type(JsonFieldType.NUMBER).description("차량의 id"),
+                                fieldWithPath("cars[1].name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("cars[1].vintage").type(JsonFieldType.STRING).description("차량 연식")
+                        )
+                ));
+    }
+
+    @Test
+    void 차량을_저장한다() throws Exception {
+        // given
+        CarsRequest request = new CarsRequest(
+                List.of(
+                        new CarRequest("아이오닉5", "2022-A"),
+                        new CarRequest("아이오닉5", "2022-A")
+                )
+        );
+
+        List<Car> cars = List.of(createCar(), createOtherCar());
+
+        // when
+        when(carService.saveCars(any(), eq(request))).thenReturn(cars);
+
+        // then
+        mockMvc.perform(post("/cars")
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                ).andExpect(status().isCreated())
+                .andDo(customDocument("save_all_cars",
+                        requestHeaders(headerWithName(org.springframework.http.HttpHeaders.AUTHORIZATION).description("인증 토큰")),
+                        requestFields(
+                                fieldWithPath("cars[0].name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("cars[0].vintage").type(JsonFieldType.STRING).description("차량 연식"),
+                                fieldWithPath("cars[1].name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("cars[1].vintage").type(JsonFieldType.STRING).description("차량 연식")
+                        ),
+                        responseFields(
+                                fieldWithPath("cars[0].carId").type(JsonFieldType.NUMBER).description("차량의 id"),
+                                fieldWithPath("cars[0].name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("cars[0].vintage").type(JsonFieldType.STRING).description("차량 연식"),
+                                fieldWithPath("cars[1].carId").type(JsonFieldType.NUMBER).description("차량의 id"),
+                                fieldWithPath("cars[1].name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("cars[1].vintage").type(JsonFieldType.STRING).description("차량 연식")
+                        )
+                ));
+    }
+
+    @Test
+    void 차량을_제거한다() throws Exception {
+        doNothing().when(carService).deleteCar(1L, 2L);
+
+        // then
+        mockMvc.perform(delete("/cars/{carId}", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                ).andExpect(status().isNoContent())
+                .andDo(customDocument("save_all_cars",
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
+                        pathParameters(
+                                parameterWithName("carId").description("차량 id")
+                        )
+                ));
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
@@ -122,6 +122,7 @@ class CarControllerTest extends MockBeanInjection {
 
     @Test
     void 차량을_제거한다() throws Exception {
+        // when
         doNothing().when(carService).deleteCar(1L, 2L);
 
         // then

--- a/backend/src/test/java/com/carffeine/carffeine/car/domain/CarFilterRepositoryTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/domain/CarFilterRepositoryTest.java
@@ -1,0 +1,70 @@
+package com.carffeine.carffeine.car.domain;
+
+import com.carffeine.carffeine.filter.domain.Filter;
+import com.carffeine.carffeine.filter.domain.FilterRepository;
+import com.carffeine.carffeine.helper.integration.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createCapacityFilter;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createCompanyFilter;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createConnectorTypeFilter;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class CarFilterRepositoryTest extends IntegrationTest {
+
+    @Autowired
+    private CarFilterRepository carFilterRepository;
+
+    @Autowired
+    private FilterRepository filterRepository;
+
+    @Autowired
+    private CarRepository carRepository;
+
+    private List<Filter> filterList;
+    private Car car;
+
+    @BeforeEach
+    void setup() {
+        filterList = filterRepository.saveAll(
+                List.of(createCompanyFilter(), createConnectorTypeFilter(), createCapacityFilter())
+        );
+
+        car = carRepository.save(Car.from("아이오닉5", "2022-A"));
+    }
+
+    @Test
+    void 모든_차량_필터를_조회한다() {
+        // given
+        carFilterRepository.saveAll(List.of(new CarFilter(car, filterList.get(0))));
+
+        // when
+        List<CarFilter> carFilters = carFilterRepository.findAllByCar(car);
+
+        // then
+        assertThat(carFilters.get(0).getFilter()).isEqualTo(filterList.get(0));
+    }
+
+    @Test
+    void 차량에_필터를_적용한다() {
+        // when
+        List<CarFilter> carFilters = carFilterRepository.saveAll(List.of(new CarFilter(car, filterList.get(0))));
+
+        // then
+        List<CarFilter> result = carFilterRepository.findAllByCar(car);
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.size()).isEqualTo(1);
+            softly.assertThat(result.get(0)).isEqualTo(carFilters.get(0));
+        });
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
@@ -31,7 +31,7 @@ class CarRepositoryTest extends IntegrationTest {
         Car foundCar = carRepository.findById(savedCar.getId()).get();
 
         // then
-        assertThat(foundCar).usingRecursiveComparison().isEqualTo(savedCar);
+        assertThat(foundCar.getName()).isEqualTo("아이오닉5");
     }
 
     @Test
@@ -40,7 +40,7 @@ class CarRepositoryTest extends IntegrationTest {
         Car foundCar = carRepository.findByNameAndVintage("아이오닉5", "2022-A").get();
 
         // then
-        assertThat(foundCar).usingRecursiveComparison().isEqualTo(savedCar);
+        assertThat(foundCar.getName()).isEqualTo("아이오닉5");
     }
 
     @Test

--- a/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
@@ -1,0 +1,74 @@
+package com.carffeine.carffeine.car.domain;
+
+import com.carffeine.carffeine.helper.integration.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class CarRepositoryTest extends IntegrationTest {
+
+    @Autowired
+    private CarRepository carRepository;
+
+    private Car car;
+
+    @BeforeEach
+    void setup() {
+        car = carRepository.save(Car.from("아이오닉5", "2022-A"));
+    }
+
+    @Test
+    void 차량을_id_찾는다() {
+        // when
+        Car foundCar = carRepository.findById(car.getId()).get();
+
+        // then
+        assertThat(foundCar).usingRecursiveComparison().isEqualTo(car);
+    }
+
+    @Test
+    void 차량을_모두_찾는다() {
+        // when
+        carRepository.save(Car.from("아이오닉5", "2022-B"));
+        List<Car> cars = carRepository.findAll();
+
+        // then
+        assertThat(cars.size()).isEqualTo(2);
+    }
+
+    @Test
+    void 차량의_이름과_연식으로_찾는다() {
+        // when
+        boolean isExistedCar = carRepository.existsByNameAndVintage("아이오닉5", "2022-A");
+
+        // then
+        assertThat(isExistedCar).isTrue();
+    }
+
+    @Test
+    void 차량을_저장한다() {
+        // when
+        Car savedCar = carRepository.save(Car.from("아이오닉5", "2022-C"));
+
+        // then
+        Car car = carRepository.findById(savedCar.getId()).get();
+        assertThat(car.getVintage()).isEqualTo(savedCar.getVintage());
+    }
+
+    @Test
+    void 차량을_제거한다() {
+        // when
+        carRepository.deleteById(1L);
+
+        // then
+        assertThat(carRepository.findAll().size()).isEqualTo(0);
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
@@ -18,20 +18,20 @@ class CarRepositoryTest extends IntegrationTest {
     @Autowired
     private CarRepository carRepository;
 
-    private Car car;
+    private Car savedCar;
 
     @BeforeEach
     void setup() {
-        car = carRepository.save(Car.from("아이오닉5", "2022-A"));
+        savedCar = carRepository.save(Car.from("아이오닉5", "2022-A"));
     }
 
     @Test
     void 차량을_id_찾는다() {
         // when
-        Car foundCar = carRepository.findById(car.getId()).get();
+        Car foundCar = carRepository.findById(savedCar.getId()).get();
 
         // then
-        assertThat(foundCar).usingRecursiveComparison().isEqualTo(car);
+        assertThat(foundCar).usingRecursiveComparison().isEqualTo(savedCar);
     }
 
     @Test
@@ -40,7 +40,7 @@ class CarRepositoryTest extends IntegrationTest {
         Car foundCar = carRepository.findByNameAndVintage("아이오닉5", "2022-A").get();
 
         // then
-        assertThat(foundCar).usingRecursiveComparison().isEqualTo(car);
+        assertThat(foundCar).usingRecursiveComparison().isEqualTo(savedCar);
     }
 
     @Test

--- a/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/domain/CarRepositoryTest.java
@@ -35,6 +35,15 @@ class CarRepositoryTest extends IntegrationTest {
     }
 
     @Test
+    void 차량의_이름과_연식으로_찾는다() {
+        // when
+        Car foundCar = carRepository.findByNameAndVintage("아이오닉5", "2022-A").get();
+
+        // then
+        assertThat(foundCar).usingRecursiveComparison().isEqualTo(car);
+    }
+
+    @Test
     void 차량을_모두_찾는다() {
         // when
         carRepository.save(Car.from("아이오닉5", "2022-B"));
@@ -45,7 +54,7 @@ class CarRepositoryTest extends IntegrationTest {
     }
 
     @Test
-    void 차량의_이름과_연식으로_찾는다() {
+    void 차량의_이름과_연식으로_존재하는지_찾는다() {
         // when
         boolean isExistedCar = carRepository.existsByNameAndVintage("아이오닉5", "2022-A");
 

--- a/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarFilterRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarFilterRepository.java
@@ -1,0 +1,54 @@
+package com.carffeine.carffeine.car.fake;
+
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarFilter;
+import com.carffeine.carffeine.car.domain.CarFilterRepository;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FakeCarFilterRepository implements CarFilterRepository {
+
+    private final Map<Long, CarFilter> map = new HashMap<>();
+    private Long id = 0L;
+
+    @Override
+    public List<CarFilter> findAllByCar(Car car) {
+        return map.values()
+                .stream()
+                .toList();
+    }
+
+    @Override
+    public <S extends CarFilter> List<S> saveAll(Iterable<S> carFilters) {
+        List<S> savedCarFilters = new ArrayList<>();
+
+        for (S carFilter : carFilters) {
+            id++;
+            CarFilter savedCarFilter = CarFilter.builder()
+                    .id(id)
+                    .car(carFilter.getCar())
+                    .filter(carFilter.getFilter())
+                    .build();
+            map.put(id, savedCarFilter);
+
+            savedCarFilters.add((S) savedCarFilter);
+        }
+
+        return savedCarFilters;
+    }
+
+    @Override
+    public void deleteAllByCar(Car car) {
+        List<Long> keys = map.keySet()
+                .stream()
+                .filter(it -> map.get(it).getCar().equals(car))
+                .toList();
+
+        for (Long key : keys) {
+            map.remove(key);
+        }
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
@@ -19,6 +19,14 @@ public class FakeCarRepository implements CarRepository {
     }
 
     @Override
+    public Optional<Car> findByNameAndVintage(final String name, final String vintage) {
+        return map.values()
+                .stream()
+                .filter(it -> it.getName().equals(name) && it.getVintage().equals(vintage))
+                .findAny();
+    }
+
+    @Override
     public List<Car> findAll() {
         return map.values()
                 .stream()

--- a/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
@@ -1,0 +1,61 @@
+package com.carffeine.carffeine.car.fake;
+
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarRepository;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeCarRepository implements CarRepository {
+
+    private final Map<Long, Car> map = new HashMap<>();
+    private Long id = 0L;
+
+    @Override
+    public Optional<Car> findById(Long carId) {
+        return Optional.of(map.get(id));
+    }
+
+    @Override
+    public List<Car> findAll() {
+        return map.values()
+                .stream()
+                .toList();
+    }
+
+    @Override
+    public boolean existsByNameAndVintage(String name, String vintage) {
+        return map.values()
+                .stream()
+                .anyMatch(it -> it.getName().equals(name) && it.getVintage().equals(vintage));
+    }
+
+    @Override
+    public Car save(Car car) {
+        this.id++;
+
+        Car savedCar = Car
+                .builder()
+                .id(this.id)
+                .name(car.getName())
+                .vintage(car.getVintage())
+                .build();
+
+        map.put(this.id, savedCar);
+        return car;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        boolean isExistedCar = map.values()
+                .stream()
+                .anyMatch(it -> it.getId().equals(id));
+
+        if (isExistedCar) {
+            map.remove(id);
+            this.id--;
+        }
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
@@ -63,7 +63,6 @@ public class FakeCarRepository implements CarRepository {
 
         if (isExistedCar) {
             map.remove(id);
-            this.id--;
         }
     }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/fake/FakeCarRepository.java
@@ -19,7 +19,7 @@ public class FakeCarRepository implements CarRepository {
     }
 
     @Override
-    public Optional<Car> findByNameAndVintage(final String name, final String vintage) {
+    public Optional<Car> findByNameAndVintage(String name, String vintage) {
         return map.values()
                 .stream()
                 .filter(it -> it.getName().equals(name) && it.getVintage().equals(vintage))

--- a/backend/src/test/java/com/carffeine/carffeine/car/fixture/CarFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/fixture/CarFixture.java
@@ -1,0 +1,22 @@
+package com.carffeine.carffeine.car.fixture;
+
+import com.carffeine.carffeine.car.domain.Car;
+
+public class CarFixture {
+
+    public static Car createCar() {
+        return Car.builder()
+                .id(1L)
+                .name("아이오닉5")
+                .vintage("2022-A")
+                .build();
+    }
+
+    public static Car createOtherCar() {
+        return Car.builder()
+                .id(2L)
+                .name("아이오닉5")
+                .vintage("2022-B")
+                .build();
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationFixture.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class CarIntegrationFixture extends IntegrationTest {
 
-    protected <T> ExtractableResponse 차량_생성_요청(String url, T request, String accessToken) {
+    protected <T> ExtractableResponse 생성_요청(String url, T request, String accessToken) {
         return RestAssured.given().log().all()
                 .body(request)
                 .contentType(ContentType.JSON)
@@ -22,7 +22,7 @@ public class CarIntegrationFixture extends IntegrationTest {
                 .extract();
     }
 
-    protected <T> ExtractableResponse 차량_제거_요청(String url, String accessToken) {
+    protected <T> ExtractableResponse 제거_요청(String url, String accessToken) {
         return RestAssured.given().log().all()
                 .header(HttpHeaders.AUTHORIZATION, accessToken)
                 .when()
@@ -31,7 +31,7 @@ public class CarIntegrationFixture extends IntegrationTest {
                 .extract();
     }
 
-    protected <T> ExtractableResponse 차량_조회_요청(String url) {
+    protected <T> ExtractableResponse 조회_요청(String url) {
         return RestAssured.given().log().all()
                 .accept(ContentType.JSON)
                 .when()

--- a/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationFixture.java
@@ -1,0 +1,46 @@
+package com.carffeine.carffeine.car.integration;
+
+import com.carffeine.carffeine.helper.integration.IntegrationTest;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.http.HttpHeaders;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class CarIntegrationFixture extends IntegrationTest {
+
+    protected <T> ExtractableResponse 차량_생성_요청(String url, T request, String accessToken) {
+        return RestAssured.given().log().all()
+                .body(request)
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when()
+                .post(url)
+                .then().log().all()
+                .extract();
+    }
+
+    protected <T> ExtractableResponse 차량_제거_요청(String url, String accessToken) {
+        return RestAssured.given().log().all()
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .when()
+                .delete(url)
+                .then().log().all()
+                .extract();
+    }
+
+    protected <T> ExtractableResponse 차량_조회_요청(String url) {
+        return RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .when()
+                .get(url)
+                .then().log().all()
+                .extract();
+    }
+
+    protected <T> Executable 단일_검증(T actual, T expected) {
+        return () -> assertThat(actual).isEqualTo(expected);
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationTest.java
@@ -1,0 +1,84 @@
+package com.carffeine.carffeine.car.integration;
+
+import com.carffeine.carffeine.auth.domain.TokenProvider;
+import com.carffeine.carffeine.car.controller.dto.CarsResponse;
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarRepository;
+import com.carffeine.carffeine.car.service.dto.CarRequest;
+import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.member.domain.Member;
+import com.carffeine.carffeine.member.domain.MemberRepository;
+import com.carffeine.carffeine.member.domain.MemberRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+public class CarIntegrationTest extends CarIntegrationFixture {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CarRepository carRepository;
+
+    @Autowired
+    private TokenProvider provider;
+
+    private Member 관리자;
+    private String 관리자_토큰;
+    private Car 저장된_차량;
+    private CarsRequest 차량_저장_리스트;
+
+    @BeforeEach
+    void setup() {
+        관리자 = memberRepository.save(Member.builder()
+                .memberRole(MemberRole.ADMIN)
+                .build());
+
+        관리자_토큰 = "Bearer " + provider.create(관리자.getId());
+
+        저장된_차량 = carRepository.save(createCar());
+
+        차량_저장_리스트 = new CarsRequest(
+                List.of(new CarRequest("아이오닉6", "2022-A"))
+        );
+    }
+
+    @Test
+    void 차량을_생성한다() {
+        // when
+        var 차량_생성_응답 = 차량_생성_요청("/cars", 차량_저장_리스트, 관리자_토큰);
+        var 차량_생성_결과 = 차량_생성_응답.body().as(CarsResponse.class);
+
+        // then
+        단일_검증(차량_생성_결과.cars().size(), 2);
+    }
+
+    @Test
+    void 차량을_모두_조회한다() {
+        // when
+        var 차량_조회_응답 = 차량_조회_요청("/cars");
+        var 차량_조회_결과 = 차량_조회_응답.body().as(CarsResponse.class);
+
+        // then
+        단일_검증(차량_조회_결과.cars().size(), 1);
+    }
+
+    @Test
+    void 차량을_제거한다() {
+        // when
+        var 차량_제거 = 차량_제거_요청("/cars/1", 관리자_토큰);
+
+        // then
+        List<Car> 차량_리스트 = carRepository.findAll();
+        단일_검증(차량_리스트.size(), 0);
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/integration/CarIntegrationTest.java
@@ -3,9 +3,17 @@ package com.carffeine.carffeine.car.integration;
 import com.carffeine.carffeine.auth.domain.TokenProvider;
 import com.carffeine.carffeine.car.controller.dto.CarsResponse;
 import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarFilter;
+import com.carffeine.carffeine.car.domain.CarFilterRepository;
 import com.carffeine.carffeine.car.domain.CarRepository;
 import com.carffeine.carffeine.car.service.dto.CarRequest;
 import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.filter.controller.dto.FiltersResponse;
+import com.carffeine.carffeine.filter.domain.Filter;
+import com.carffeine.carffeine.filter.domain.FilterRepository;
+import com.carffeine.carffeine.filter.domain.FilterType;
+import com.carffeine.carffeine.filter.service.dto.FilterRequest;
+import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
 import com.carffeine.carffeine.member.domain.Member;
 import com.carffeine.carffeine.member.domain.MemberRepository;
 import com.carffeine.carffeine.member.domain.MemberRole;
@@ -18,6 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.util.List;
 
 import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createCapacityFilter;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createCompanyFilter;
+import static com.carffeine.carffeine.filter.fixture.FilterFixture.createConnectorTypeFilter;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -32,10 +43,18 @@ public class CarIntegrationTest extends CarIntegrationFixture {
     @Autowired
     private TokenProvider provider;
 
+    @Autowired
+    private FilterRepository filterRepository;
+
+    @Autowired
+    private CarFilterRepository carFilterRepository;
+
     private Member 관리자;
     private String 관리자_토큰;
     private Car 저장된_차량;
     private CarsRequest 차량_저장_리스트;
+    private List<Filter> 저장된_필터;
+    private FiltersRequest 필터_요청_리스트;
 
     @BeforeEach
     void setup() {
@@ -50,12 +69,22 @@ public class CarIntegrationTest extends CarIntegrationFixture {
         차량_저장_리스트 = new CarsRequest(
                 List.of(new CarRequest("아이오닉6", "2022-A"))
         );
+
+        저장된_필터 = filterRepository.saveAll(List.of(createCompanyFilter(), createConnectorTypeFilter(), createCapacityFilter()));
+        carFilterRepository.saveAll(List.of(new CarFilter(저장된_차량, 저장된_필터.get(0))));
+
+        필터_요청_리스트 = new FiltersRequest(
+                List.of(
+                        new FilterRequest(FilterType.COMPANY.getName(), "HG"),
+                        new FilterRequest(FilterType.CAPACITY.getName(), "2.00")
+                )
+        );
     }
 
     @Test
     void 차량을_생성한다() {
         // when
-        var 차량_생성_응답 = 차량_생성_요청("/cars", 차량_저장_리스트, 관리자_토큰);
+        var 차량_생성_응답 = 생성_요청("/cars", 차량_저장_리스트, 관리자_토큰);
         var 차량_생성_결과 = 차량_생성_응답.body().as(CarsResponse.class);
 
         // then
@@ -65,7 +94,7 @@ public class CarIntegrationTest extends CarIntegrationFixture {
     @Test
     void 차량을_모두_조회한다() {
         // when
-        var 차량_조회_응답 = 차량_조회_요청("/cars");
+        var 차량_조회_응답 = 조회_요청("/cars");
         var 차량_조회_결과 = 차량_조회_응답.body().as(CarsResponse.class);
 
         // then
@@ -75,10 +104,31 @@ public class CarIntegrationTest extends CarIntegrationFixture {
     @Test
     void 차량을_제거한다() {
         // when
-        var 차량_제거 = 차량_제거_요청("/cars/1", 관리자_토큰);
+        제거_요청("/cars/1", 관리자_토큰);
 
         // then
         List<Car> 차량_리스트 = carRepository.findAll();
         단일_검증(차량_리스트.size(), 0);
+    }
+
+    @Test
+    void 차량에_적용된_필터를_찾는다() {
+        // when
+        var 차량_필터_조회_요청_응답 = 조회_요청("/cars/1/filters");
+        var 차량_필터_조회_요청_결과 = 차량_필터_조회_요청_응답.body().as(FiltersResponse.class);
+
+        // then
+        단일_검증(차량_필터_조회_요청_결과.companies().get(0), 저장된_필터.get(0).getName());
+    }
+
+    @Test
+    void 차량에_필터를_적용한다() {
+        // when
+        var 차량_필터_생성_응답 = 생성_요청("/cars/1/filters", 필터_요청_리스트, 관리자_토큰);
+        var 차량_필터_생성_결과 = 차량_필터_생성_응답.body().as(FiltersResponse.class);
+
+        // then
+        단일_검증(차량_필터_생성_결과.companies().get(0), 저장된_필터.get(0).getName());
+        단일_검증(차량_필터_생성_결과.capacities().get(0), 저장된_필터.get(2).getName());
     }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/car/service/CarServiceTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/service/CarServiceTest.java
@@ -1,0 +1,139 @@
+package com.carffeine.carffeine.car.service;
+
+import com.carffeine.carffeine.admin.exception.AdminException;
+import com.carffeine.carffeine.admin.exception.AdminExceptionType;
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarRepository;
+import com.carffeine.carffeine.car.fake.FakeCarRepository;
+import com.carffeine.carffeine.car.service.dto.CarRequest;
+import com.carffeine.carffeine.car.service.dto.CarsRequest;
+import com.carffeine.carffeine.member.domain.FakeMemberRepository;
+import com.carffeine.carffeine.member.domain.Member;
+import com.carffeine.carffeine.member.domain.MemberRepository;
+import com.carffeine.carffeine.member.domain.MemberRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+class CarServiceTest {
+
+    private CarService carService;
+    private MemberRepository memberRepository;
+    private CarRepository carRepository;
+
+    private Member member;
+    private Member admin;
+
+    @BeforeEach
+    void setup() {
+        memberRepository = new FakeMemberRepository();
+        carRepository = new FakeCarRepository();
+        carService = new CarService(
+                memberRepository,
+                carRepository
+        );
+        member = memberRepository.save(Member.builder()
+                .id(1L)
+                .memberRole(MemberRole.USER)
+                .build());
+
+        admin = memberRepository.save(Member.builder()
+                .memberRole(MemberRole.ADMIN)
+                .build());
+    }
+
+    @Test
+    void 차량을_모두_조회한다() {
+        // given
+        Car savedCar = carRepository.save(createCar());
+
+        // when
+        List<Car> result = carService.findAllCars();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.size()).isEqualTo(1);
+            softly.assertThat(savedCar).usingRecursiveComparison().isEqualTo(result.get(0));
+        });
+    }
+
+    @Test
+    void 차량을_저장한다() {
+        // given
+        CarsRequest request = new CarsRequest(
+                List.of(
+                        new CarRequest("아이오닉5", "2022-A"),
+                        new CarRequest("아이오닉5", "2022-B")
+                )
+        );
+
+        // when
+        List<Car> result = carService.saveCars(admin.getId(), request);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.size()).isEqualTo(2);
+            softly.assertThat(result.get(0).getVintage()).isEqualTo("2022-A");
+            softly.assertThat(result.get(1).getVintage()).isEqualTo("2022-B");
+        });
+    }
+
+    @Test
+    void 저장하려는_차량이_중복이면_제외하고_저장한다() {
+        // given
+        carRepository.save(Car.from("아이오닉5", "2022-A"));
+
+        CarsRequest request = new CarsRequest(
+                List.of(
+                        new CarRequest("아이오닉5", "2022-A"),
+                        new CarRequest("아이오닉5", "2022-B")
+                )
+        );
+
+        // when
+        List<Car> result = carService.saveCars(admin.getId(), request);
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+    }
+
+    @Test
+    void 어드민이_아니면_차량을_저장하지_못한다() {
+        // given
+        CarsRequest request = new CarsRequest(
+                List.of(
+                        new CarRequest("아이오닉5", "2022-A"),
+                        new CarRequest("아이오닉5", "2022-B")
+                )
+        );
+
+        // when & then
+        assertThatThrownBy(() -> carService.saveCars(member.getId(), request))
+                .isInstanceOf(AdminException.class)
+                .hasMessage(AdminExceptionType.NOT_ADMIN.message());
+    }
+
+    @Test
+    void 차량을_삭제한다() {
+        // given
+        Car savedCar = carRepository.save(createCar());
+        int beforeSize = carRepository.findAll().size();
+
+        // when
+        carService.deleteCar(admin.getId(), savedCar.getId());
+
+        // then
+        int afterSize = carRepository.findAll().size();
+        assertThat(afterSize).isEqualTo(beforeSize - 1);
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/filter/fixture/FilterFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/filter/fixture/FilterFixture.java
@@ -1,0 +1,19 @@
+package com.carffeine.carffeine.filter.fixture;
+
+import com.carffeine.carffeine.filter.domain.Filter;
+import com.carffeine.carffeine.filter.domain.FilterType;
+
+public class FilterFixture {
+
+    public static Filter createCompanyFilter() {
+        return Filter.of("HG", FilterType.COMPANY.getName());
+    }
+
+    public static Filter createCapacityFilter() {
+        return Filter.of("2.00", FilterType.CAPACITY.getName());
+    }
+
+    public static Filter createConnectorTypeFilter() {
+        return Filter.of("DC_COMBO", FilterType.CONNECTOR_TYPE.getName());
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/helper/MockBeanInjection.java
+++ b/backend/src/test/java/com/carffeine/carffeine/helper/MockBeanInjection.java
@@ -7,10 +7,11 @@ import com.carffeine.carffeine.auth.controller.AuthMemberResolver;
 import com.carffeine.carffeine.auth.domain.TokenProvider;
 import com.carffeine.carffeine.auth.service.AuthService;
 import com.carffeine.carffeine.auth.service.OAuthRequester;
+import com.carffeine.carffeine.car.service.CarService;
 import com.carffeine.carffeine.filter.service.FilterService;
 import com.carffeine.carffeine.member.domain.MemberRepository;
-import com.carffeine.carffeine.station.domain.review.ReviewRepository;
 import com.carffeine.carffeine.member.service.MemberService;
+import com.carffeine.carffeine.station.domain.review.ReviewRepository;
 import com.carffeine.carffeine.station.service.congestion.CongestionService;
 import com.carffeine.carffeine.station.service.report.ReportService;
 import com.carffeine.carffeine.station.service.review.ReviewService;
@@ -51,4 +52,6 @@ public class MockBeanInjection {
     protected FilterService filterService;
     @MockBean
     protected MemberService memberService;
+    @MockBean
+    protected CarService carService;
 }

--- a/backend/src/test/java/com/carffeine/carffeine/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/member/controller/MemberControllerTest.java
@@ -1,11 +1,14 @@
 package com.carffeine.carffeine.member.controller;
 
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.service.dto.CarRequest;
 import com.carffeine.carffeine.filter.domain.Filter;
 import com.carffeine.carffeine.filter.domain.FilterType;
 import com.carffeine.carffeine.filter.service.dto.FilterRequest;
 import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
 import com.carffeine.carffeine.helper.MockBeanInjection;
 import com.carffeine.carffeine.member.domain.Member;
+import com.carffeine.carffeine.member.domain.MemberCar;
 import com.carffeine.carffeine.member.domain.MemberFilter;
 import com.carffeine.carffeine.member.fixture.MemberFixture;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -22,6 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
 import static com.carffeine.carffeine.helper.RestDocsHelper.customDocument;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -67,9 +71,7 @@ class MemberControllerTest extends MockBeanInjection {
                 ).andExpect(status().isOk())
                 .andDo(customDocument("find_member_filters",
                                 requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
-                                pathParameters(
-                                        parameterWithName("memberId").description("Member id")
-                                ),
+                                pathParameters(parameterWithName("memberId").description("Member id")),
                                 responseFields(
                                         fieldWithPath("companies[0]").type(JsonFieldType.ARRAY).description("충전기 회사"),
                                         fieldWithPath("capacities[0]").type(JsonFieldType.ARRAY).description("충전 용량"),
@@ -109,9 +111,7 @@ class MemberControllerTest extends MockBeanInjection {
                 ).andExpect(status().isOk())
                 .andDo(customDocument("add_member_filters",
                                 requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
-                                pathParameters(
-                                        parameterWithName("memberId").description("Member id")
-                                ),
+                                pathParameters(parameterWithName("memberId").description("Member id")),
                                 requestFields(
                                         fieldWithPath("filters[0].type").type(JsonFieldType.STRING).description("필터 종류"),
                                         fieldWithPath("filters[0].name").type(JsonFieldType.STRING).description("필터 이름"),
@@ -127,5 +127,59 @@ class MemberControllerTest extends MockBeanInjection {
                                 )
                         )
                 );
+    }
+
+    @Test
+    void 회원이_등록한_차량을_조회한다() throws Exception {
+        // given
+        MemberCar memberCar = new MemberCar(MemberFixture.일반_회원, createCar());
+
+        // when
+        when(memberService.findMemberCar(any())).thenReturn(memberCar);
+
+        // then
+        mockMvc.perform(get("/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                ).andExpect(status().isOk())
+                .andDo(customDocument("find_member_car",
+                                requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
+                                responseFields(
+                                        fieldWithPath("memberId").type(JsonFieldType.NUMBER).description("유저 id"),
+                                        fieldWithPath("car.carId").type(JsonFieldType.NUMBER).description("차량 id"),
+                                        fieldWithPath("car.name").type(JsonFieldType.STRING).description("차량 이름"),
+                                        fieldWithPath("car.vintage").type(JsonFieldType.STRING).description("차량 연식")
+                                )
+                        )
+                );
+    }
+
+    @Test
+    void 회원의_차량을_등록한다() throws Exception {
+        // given
+        Car car = createCar();
+        CarRequest carRequest = new CarRequest("아이오닉5", "2022-A");
+
+        // when
+        when(memberService.addMemberCar(any(), any(), any())).thenReturn(car);
+
+        // then
+        mockMvc.perform(post("/members/{memberId}/cars", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(carRequest))
+                ).andExpect(status().isCreated())
+                .andDo(customDocument("add_member_car",
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
+                        pathParameters(parameterWithName("memberId").description("Member id")),
+                        requestFields(
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("vintage").type(JsonFieldType.STRING).description("차량 연식")
+                        ),
+                        responseFields(
+                                fieldWithPath("carId").type(JsonFieldType.NUMBER).description("차량 id"),
+                                fieldWithPath("name").type(JsonFieldType.STRING).description("차량 이름"),
+                                fieldWithPath("vintage").type(JsonFieldType.STRING).description("차량 연식")
+                        )
+                ));
     }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/member/domain/FakeMemberCarRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/member/domain/FakeMemberCarRepository.java
@@ -1,0 +1,44 @@
+package com.carffeine.carffeine.member.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeMemberCarRepository implements MemberCarRepository {
+
+    private final Map<Long, MemberCar> map = new HashMap<>();
+    private Long id = 0L;
+
+    @Override
+    public Optional<MemberCar> findByMember(Member member) {
+        return map.values()
+                .stream()
+                .filter(it -> it.getMember().isSame(member.getId()))
+                .findAny();
+    }
+
+    @Override
+    public MemberCar save(MemberCar memberCar) {
+        id++;
+        map.put(id, memberCar);
+        return map.get(id);
+    }
+
+    @Override
+    public void deleteByMember(Member member) {
+        boolean isExist = map.keySet()
+                .stream()
+                .anyMatch(it -> map.get(it).getMember().isSame(member.getId()));
+
+        if (isExist) {
+            Long key = map.keySet()
+                    .stream()
+                    .filter(it -> map.get(it).getMember().isSame(member.getId()))
+                    .findAny()
+                    .get();
+
+            map.remove(key);
+            key--;
+        }
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/member/integration/MemberFilterIntegrationFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/member/integration/MemberFilterIntegrationFixture.java
@@ -22,7 +22,7 @@ public class MemberFilterIntegrationFixture extends IntegrationTest {
                 .extract();
     }
 
-    protected <T> ExtractableResponse 모든_필터_조회_요청(String url, String accessToken) {
+    protected <T> ExtractableResponse 조회_요청(String url, String accessToken) {
         return RestAssured.given().log().all()
                 .accept(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, accessToken)

--- a/backend/src/test/java/com/carffeine/carffeine/member/integration/MemberFilterIntegrationTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/member/integration/MemberFilterIntegrationTest.java
@@ -1,13 +1,19 @@
 package com.carffeine.carffeine.member.integration;
 
 import com.carffeine.carffeine.auth.domain.TokenProvider;
+import com.carffeine.carffeine.car.controller.dto.CarResponse;
+import com.carffeine.carffeine.car.domain.Car;
+import com.carffeine.carffeine.car.domain.CarRepository;
 import com.carffeine.carffeine.filter.controller.dto.FiltersResponse;
 import com.carffeine.carffeine.filter.domain.Filter;
 import com.carffeine.carffeine.filter.domain.FilterRepository;
 import com.carffeine.carffeine.filter.domain.FilterType;
 import com.carffeine.carffeine.filter.service.dto.FilterRequest;
 import com.carffeine.carffeine.filter.service.dto.FiltersRequest;
+import com.carffeine.carffeine.member.controller.dto.MemberCarInfoResponse;
 import com.carffeine.carffeine.member.domain.Member;
+import com.carffeine.carffeine.member.domain.MemberCar;
+import com.carffeine.carffeine.member.domain.MemberCarRepository;
 import com.carffeine.carffeine.member.domain.MemberRepository;
 import com.carffeine.carffeine.member.domain.MemberRole;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,6 +23,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+
+import static com.carffeine.carffeine.car.fixture.CarFixture.createCar;
+import static com.carffeine.carffeine.car.fixture.CarFixture.createOtherCar;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SuppressWarnings("NonAsciiCharacters")
@@ -29,11 +38,19 @@ public class MemberFilterIntegrationTest extends MemberFilterIntegrationFixture 
     private FilterRepository filterRepository;
 
     @Autowired
+    private CarRepository carRepository;
+
+    @Autowired
+    private MemberCarRepository memberCarRepository;
+
+    @Autowired
     private TokenProvider provider;
 
     private FiltersRequest 충전_속도_필터_리스트;
     private Member 일반_유저;
     private String 유저_토큰;
+    private Car 존재하는_자동차;
+    private Car 존재하는_자동차2;
 
     @BeforeEach
     void setup() {
@@ -54,12 +71,17 @@ public class MemberFilterIntegrationTest extends MemberFilterIntegrationFixture 
                         new FilterRequest(FilterType.CAPACITY.getName(), "2.00")
                 )
         );
+
+        존재하는_자동차 = carRepository.save(createCar());
+        존재하는_자동차2 = carRepository.save(createOtherCar());
+
+        memberCarRepository.save(new MemberCar(일반_유저, 존재하는_자동차));
     }
 
     @Test
     void 유저의_모든_필터를_조회한다() {
         // when
-        var 모든_필터_조회_응답 = 모든_필터_조회_요청("/members/" + 일반_유저.getId() + "/filters", 유저_토큰);
+        var 모든_필터_조회_응답 = 조회_요청("/members/" + 일반_유저.getId() + "/filters", 유저_토큰);
         var 필터_조회_결과 = 모든_필터_조회_응답.body().as(FiltersResponse.class);
 
         // then
@@ -74,5 +96,25 @@ public class MemberFilterIntegrationTest extends MemberFilterIntegrationFixture 
 
         // then
         단일_검증(생성_요청_결과.companies().size(), 0);
+    }
+
+    @Test
+    void 유저가_등록한_차량을_조회한다() {
+        // when
+        var 유저_차량_조회_응답 = 조회_요청("/members/me", 유저_토큰);
+        var 유저_차량_조회_결과 = 유저_차량_조회_응답.body().as(MemberCarInfoResponse.class);
+
+        // then
+        단일_검증(유저_차량_조회_결과.car().name(), 존재하는_자동차.getName());
+    }
+
+    @Test
+    void 유저가_차량을_등록한다() {
+        // when
+        var 유저_차량_생성_응답 = 생성_요청("/members/" + 일반_유저.getId() + "/cars", 존재하는_자동차2, 유저_토큰);
+        var 유저_차량_생성_결과 = 유저_차량_생성_응답.body().as(CarResponse.class);
+
+        // then
+        단일_검증(유저_차량_생성_결과.name(), 존재하는_자동차2.getName());
     }
 }


### PR DESCRIPTION
## 📄 Summary
차량 개인화를 위해 Car 테이블을 만들었습니다. 차량 정보는 어드민 페이지에서 추가할 수 있습니다.

또한 차량에 해당하는 필터를 관리하기 위해 CarFilter 테이블을 만들고, 이는 관리자 페이지에서 적용할 수 있습니다.

마지막으로 유저가 개인의 차량을 등록하고 조회할 수 있는 기능을 구현했습니다.

테이블 구조는 다음과 같습니다.
1. 차량 - Car (id, name, year)
2. 멤버 차량 - MemberCar(id, member_id, car_id)
3. 차량 필터 - CarFilter (id, car_id, filter_id)

## 🕰️ Actual Time of Completion
> 

## 🙋🏻 More
> 


close #455