### PR TITLE
Skeleton을 감싸고 있는 불필요한 spacing용 Box 제거한다

### DIFF
--- a/frontend/src/components/common/Skeleton/Skeleton.stories.tsx
+++ b/frontend/src/components/common/Skeleton/Skeleton.stories.tsx
@@ -43,12 +43,8 @@ export const Default = (args: SkeletonProps) => {
 export const Example = () => {
   return (
     <>
-      <Box mb={2}>
-        <Skeleton />
-      </Box>
-      <Box mb={2}>
-        <Skeleton width="40rem" height="30rem" />
-      </Box>
+      <Skeleton mb={2} />
+      <Skeleton width="40rem" height="30rem" mb={2} />
       <Skeleton width="10rem" height="10rem" borderRadius="50%" />
     </>
   );

--- a/frontend/src/components/ui/StationDetailsWindow/StationDetailsViewSkeleton.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/StationDetailsViewSkeleton.tsx
@@ -10,11 +10,9 @@ const StationDetailsViewSkeleton = () => {
   return (
     <Box px={2} py={10} css={stationDetailsViewContainerCss}>
       <StationInformationSkeleton />
-      <Box my={3}>
-        <FlexBox justifyContent="center">
-          <Skeleton width="90%" height="3rem" />
-        </FlexBox>
-      </Box>
+      <FlexBox justifyContent="center" my={3}>
+        <Skeleton width="90%" height="3rem" />
+      </FlexBox>
       <FlexBox>
         {Array.from({ length: 10 }, (_, index) => (
           <ChargerCardSkeleton key={index} />

--- a/frontend/src/components/ui/StationDetailsWindow/chargers/ChargerCardSkeleton.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/chargers/ChargerCardSkeleton.tsx
@@ -1,5 +1,3 @@
-import { css } from 'styled-components';
-
 import Box from '@common/Box';
 import FlexBox from '@common/FlexBox';
 import Skeleton from '@common/Skeleton';
@@ -7,21 +5,11 @@ import Skeleton from '@common/Skeleton';
 const ChargerCardSkeleton = () => {
   return (
     <Box border px={2} py={5} width={39}>
-      <Box mb={1}>
-        <Skeleton width="100%" height="2.8rem" />
-      </Box>
-      <Box mb={1}>
-        <Skeleton width="5rem" height="1.2rem" />
-      </Box>
-      <Box mb={1}>
-        <Skeleton width="5rem" height="1.2rem" />
-      </Box>
-      <Box mb={1}>
-        <Skeleton width="5rem" height="1.2rem" />
-      </Box>
-      <Box mb={1}>
-        <Skeleton width="5rem" height="1.2rem" />
-      </Box>
+      <Skeleton width="100%" height="2.8rem" mb={1} />
+      <Skeleton width="5rem" height="1.2rem" mb={1} />
+      <Skeleton width="5rem" height="1.2rem" mb={1} />
+      <Skeleton width="5rem" height="1.2rem" mb={1} />
+      <Skeleton width="5rem" height="1.2rem" mb={1} />
       <FlexBox justifyContent="end" alignItems="center">
         <Skeleton width="5rem" height="1rem" />
       </FlexBox>

--- a/frontend/src/components/ui/StationDetailsWindow/reviews/ReviewCardSkeleton.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/reviews/ReviewCardSkeleton.tsx
@@ -5,20 +5,10 @@ const ReviewCardSkeleton = () => {
   return (
     <>
       <Box p={4} mb={4}>
-        <Box>
-          <Box mb={2}>
-            <Skeleton width="10rem" height="1.2rem" />
-          </Box>
-          <Skeleton width="5rem" height="1.2rem" />
-        </Box>
-        <Box my={3}>
-          <Box mb={2}>
-            <Skeleton width="100%" height="1.2rem" />
-          </Box>
-          <Box mb={2}>
-            <Skeleton width="100%" height="1.2rem" />
-          </Box>
-        </Box>
+        <Skeleton width="10rem" height="1.2rem" mb={2} />
+        <Skeleton width="5rem" height="1.2rem" mb={3} />
+        <Skeleton width="100%" height="1.2rem" mb={2} />
+        <Skeleton width="100%" height="1.2rem" mb={5} />
         <Skeleton width="5rem" height="1.2rem" />
       </Box>
     </>

--- a/frontend/src/components/ui/StationDetailsWindow/station/StationInformationSkeleton.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/station/StationInformationSkeleton.tsx
@@ -1,48 +1,25 @@
-import Alert from '@common/Alert';
 import Box from '@common/Box';
 import Skeleton from '@common/Skeleton';
-import Text from '@common/Text';
 
 const StationInformationSkeleton = () => {
   return (
     <Box p={3}>
       <Box px={1}>
         <Skeleton width="10rem" height="1.4rem" />
-        <Box my={1}>
-          <Skeleton width="15rem" height="2.2rem" />
-        </Box>
-        <Box mb={1}>
-          <Skeleton width="20rem" height="1.6rem" />
-        </Box>
+        <Skeleton width="15rem" height="2.2rem" my={1} />
+        <Skeleton width="20rem" height="1.6rem" mb={1} />
         <Skeleton width="10rem" height="1.2rem" />
       </Box>
       <hr />
-      <Skeleton width="100%" height="6rem" />
       <Box px={1}>
-        <Box my={2}>
-          <Box mb={1}>
-            <Skeleton width="7rem" height="1.6rem" />
-          </Box>
-          <Skeleton width="20rem" height="1.5rem" />
-        </Box>
-        <Box my={2}>
-          <Box mb={1}>
-            <Skeleton width="7rem" height="1.6rem" />
-          </Box>
-          <Skeleton width="20rem" height="1.5rem" />
-        </Box>
-        <Box my={2}>
-          <Box mb={1}>
-            <Skeleton width="7rem" height="1.6rem" />
-          </Box>
-          <Skeleton width="20rem" height="1.5rem" />
-        </Box>
-        <Box my={2}>
-          <Box mb={1}>
-            <Skeleton width="7rem" height="1.6rem" />
-          </Box>
-          <Skeleton width="20rem" height="1.5rem" />
-        </Box>
+        <Skeleton width="7rem" height="1.6rem" mt={2} mb={1} />
+        <Skeleton width="20rem" height="1.5rem" mb={2} />
+        <Skeleton width="7rem" height="1.6rem" mt={2} mb={1} />
+        <Skeleton width="20rem" height="1.5rem" mb={2} />
+        <Skeleton width="7rem" height="1.6rem" mt={2} mb={1} />
+        <Skeleton width="20rem" height="1.5rem" mb={2} />
+        <Skeleton width="7rem" height="1.6rem" mt={2} mb={1} />
+        <Skeleton width="20rem" height="1.5rem" mb={2} />
       </Box>
     </Box>
   );

--- a/frontend/src/components/ui/StationList/StationSummaryCardSkeleton.tsx
+++ b/frontend/src/components/ui/StationList/StationSummaryCardSkeleton.tsx
@@ -12,18 +12,10 @@ const StationSummaryCardSkeleton = () => {
       <Button width="100%" shadow css={foundStationButton}>
         <FlexBox alignItems="start" justifyContent="between" nowrap columnGap={2.8}>
           <Box>
-            <Box mb={2}>
-              <Skeleton width="7rem" height="1.2rem" />
-            </Box>
-            <Box mb={3}>
-              <Skeleton width="15rem" height="2.2rem" />
-            </Box>
-            <Box mb={2}>
-              <Skeleton width="10rem" height="1.6rem" />
-            </Box>
-            <Box mb={3}>
-              <Skeleton width="17rem" height="1.5rem" />
-            </Box>
+            <Skeleton width="7rem" height="1.2rem" mb={2} />
+            <Skeleton width="15rem" height="2.2rem" mb={3} />
+            <Skeleton width="10rem" height="1.6rem" mb={2} />
+            <Skeleton width="17rem" height="1.5rem" mb={3} />
             <FlexBox columnGap={3}>
               <Skeleton width="8rem" height="2.2rem" />
               <Skeleton width="8rem" height="2.2rem" />

--- a/frontend/src/components/ui/StationSearchWindow/SearchResultSkeleton.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/SearchResultSkeleton.tsx
@@ -11,12 +11,8 @@ const SearchResultSkeleton = () => {
       {Array.from({ length: 10 }, (_, index) => (
         <ListItem divider NoLastDivider key={index} css={foundStationList}>
           <Box p={2}>
-            <Box mb={2}>
-              <Skeleton width="12rem" height="1.2rem" />
-            </Box>
-            <Box>
-              <Skeleton width="24rem" />
-            </Box>
+            <Skeleton width="12rem" height="1.2rem" mb={2} />
+            <Skeleton width="24rem" />
           </Box>
         </ListItem>
       ))}


### PR DESCRIPTION
[#461]

## 📄 Summary
> 똑똑해진 Skeleton의 간격조절 능력을 잘 활용하기 위해 불필요한 간격 조절용 Box를 제거합니다.

로직 변경 없으니 빠른 검토가 가능할거에요

다음은 슬랙에 적어놨던 메시지를 남깁니다.

# 지금 develop을 pull 댕기면 사용할 수 있는 기능을 소개합니다.
기존에 Box만 가지고 있던 spacing 기능을 공통 스타일 컴포넌트들이 사용할 수 있습니다.

### 기존
```typescript
<Box mb={1}>
    <Skeleton width="5rem" height="1.2rem" />
</Box>
```

### 개선
```typescript
<Skeleton width="5rem" height="1.2rem" mb={1}/>
```

간격을 주기 위해 불필요한 태그가 생성되는일을 방지할 수 있고
모든 컴포넌트들이 숫자에 대해서 동일한 간격을 유지할 수 있는 효과를 가지고 있습니다.
일단 #461에서 다른 브랜치에 영향이 없는 스켈레톤부터 리팩터링을 진행하고 있음.
혹시 다른 스타일 컴포넌트들도 이 기능이 필요하다면 사용해주시면 됩니다.
아직 모든 스타일 컴포넌트에 이 기능을 주지 않았습니다. 만약에 본인이 사용하려는 스타일 컴포넌트에 해당 프롭들이 존재하지 않는다면 다음과 같이 해주세요

### 기존의 인터페이스에 SpacingProps(경로 까먹었으니 자동 임포트 하세요)을 확장한다
```typescript
export interface SkeletonProps extends SpacingProps { // 속성 확장하기
  width?: string;
  height?: string;
  borderRadius?: string;
}
```
### styled-components에 해당 spacing css(이것도 자동 임포트ㄱㄱ) 삽입하기
```typescript
const SkeletonWrapper = styled.div<SkeletonProps>`
  ${spacing}; // 추가 된 부분

  width: ${({ width }) => width || '100%'};
  ...
```

이렇게 수정하고 해당 컴포넌트로 돌아가서 자동 임포트를 시도하면 m, p, px, mx 이런거 다른 컴포넌트들이랑 같은 간격 만큼 줄 수 있습니다. 

## 🕰️ Actual Time of Completion
> 20분

## 🙋🏻 More
> 


close #461