### PR TITLE
refactor: MemberCar 찾지를 못하면 null을 반환한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/member/exception/MemberExceptionType.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/exception/MemberExceptionType.java
@@ -8,7 +8,8 @@ public enum MemberExceptionType implements ExceptionType {
     NOT_FOUND(Status.NOT_FOUND, 3001, "회원이 없습니다"),
     NOT_FOUND_ROLE(Status.NOT_FOUND, 3002, "일치하는 권한이 없습니다"),
     INVALID_ACCESS(Status.INVALID, 3003, "본인의 계정이 아닙니다"),
-    CAR_NOT_FOUND(Status.NOT_FOUND, 3004, "해당 유저의 차량을 찾을 수 없습니다");
+    CAR_NOT_FOUND(Status.NOT_FOUND, 3004, "해당 유저의 차량을 찾을 수 없습니다"),
+    UNAUTHORIZED(Status.UNAUTHORIZED, 3005, "접근 정보가 잘못되었습니다");
 
     private final Status status;
     private final int exceptionCode;

--- a/backend/src/main/java/com/carffeine/carffeine/member/service/MemberService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/service/MemberService.java
@@ -108,6 +108,6 @@ public class MemberService {
 
     private MemberCar getMemberCar(Member member) {
         return memberCarRepository.findByMember(member)
-                .orElseThrow(() -> new MemberException(MemberExceptionType.CAR_NOT_FOUND));
+                .orElseThrow(() -> null);
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/member/service/MemberService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/member/service/MemberService.java
@@ -46,7 +46,7 @@ public class MemberService {
 
     private Member findMember(Long memberId, Long loginMember) {
         Member member = memberRepository.findById(loginMember)
-                .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberExceptionType.UNAUTHORIZED));
 
         validateMember(memberId, member);
         return member;
@@ -101,7 +101,7 @@ public class MemberService {
     @Transactional(readOnly = true)
     public MemberCar findMemberCar(Long loginMember) {
         Member member = memberRepository.findById(loginMember)
-                .orElseThrow(() -> new MemberException(MemberExceptionType.NOT_FOUND));
+                .orElseThrow(() -> new MemberException(MemberExceptionType.UNAUTHORIZED));
 
         return getMemberCar(member);
     }


### PR DESCRIPTION
## 📄 Summary
> 유저의 차량을 찾지 못하면 null을 보냅니다.
현재는 찾지 못하면 exception을 보내는데, null을 보내야 프론트에서 처리할 수 있습니다.

## 🕰️ Actual Time of Completion
> 10분

## 🙋🏻 More
> 


close #491