### PR TITLE
refactor: 리뷰의 평균 별점을 가져올 때 발생하는 에러를 해결한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/review/ReviewController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/review/ReviewController.java
@@ -65,7 +65,7 @@ public class ReviewController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("stations/{stationId}/total-ratings")
+    @GetMapping("/stations/{stationId}/total-ratings")
     public ResponseEntity<TotalRatingsResponse> findTotalRatings(
             @PathVariable String stationId) {
         double totalRatings = reviewService.findAverageRatings(stationId);

--- a/backend/src/main/java/com/carffeine/carffeine/station/domain/review/ReviewRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/domain/review/ReviewRepository.java
@@ -20,5 +20,5 @@ public interface ReviewRepository extends Repository<Review, Long> {
     Long countByStation(Station station);
 
     @Query("SELECT AVG(r.ratings) FROM Review r WHERE r.station = :station")
-    Double findAverageRatingsByStation(@Param("station") Station station);
+    Optional<Double> findAverageRatingsByStation(@Param("station") Station station);
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/review/ReviewService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/review/ReviewService.java
@@ -29,6 +29,8 @@ import static com.carffeine.carffeine.station.exception.review.ReviewExceptionTy
 @Service
 public class ReviewService {
 
+    private static final double DEFAULT_AVERAGE_RATING = 0.0;
+
     private final ReviewRepository reviewRepository;
     private final ReplyRepository replyRepository;
     private final StationRepository stationRepository;
@@ -89,14 +91,22 @@ public class ReviewService {
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public Review findReview(Long reviewId) {
         return reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new ReviewException(REVIEW_NOT_FOUND));
     }
 
-    public double findAverageRatings(String stationId) {
+    @Transactional(readOnly = true)
+    public Double findAverageRatings(String stationId) {
         Station station = findStation(stationId);
-        return reviewRepository.findAverageRatingsByStation(station);
+        return reviewRepository.findAverageRatingsByStation(station)
+                .map(this::parseToOneDecimalPoint)
+                .orElse(DEFAULT_AVERAGE_RATING);
+    }
+
+    private double parseToOneDecimalPoint(Double rating) {
+        return Math.round(rating * 10.0) / 10.0;
     }
 
     public long findTotalCount(String stationId) {

--- a/backend/src/test/java/com/carffeine/carffeine/station/domain/review/FakeReviewRepository.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/domain/review/FakeReviewRepository.java
@@ -50,12 +50,12 @@ public class FakeReviewRepository implements ReviewRepository {
     }
 
     @Override
-    public Double findAverageRatingsByStation(Station station) {
-        return map.values().stream()
+    public Optional<Double> findAverageRatingsByStation(Station station) {
+        return Optional.of(map.values().stream()
                 .filter(it -> it.getStation().getStationId().equals(station.getStationId()))
                 .mapToDouble(Review::getRatings)
                 .average()
-                .orElse(0.0);
+                .orElse(0.0));
     }
 
     @Override

--- a/backend/src/test/java/com/carffeine/carffeine/station/domain/review/ReviewRepositoryTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/domain/review/ReviewRepositoryTest.java
@@ -82,7 +82,7 @@ class ReviewRepositoryTest {
         Station station = 선릉역_충전소_충전기_2개_사용가능_1개;
 
         // when
-        Double averageRatings = reviewRepository.findAverageRatingsByStation(station);
+        Double averageRatings = reviewRepository.findAverageRatingsByStation(station).get();
 
         // then
         assertThat(averageRatings).isEqualTo(2.0);

--- a/backend/src/test/java/com/carffeine/carffeine/station/service/review/ReviewServiceTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/service/review/ReviewServiceTest.java
@@ -214,4 +214,17 @@ class ReviewServiceTest {
         // then
         assertThat(totalCount).isEqualTo(2);
     }
+
+    @Test
+    void 리뷰가_없다면_0점을_반환한다() {
+        // given
+        Station station = 선릉역_충전소_충전기_2개_사용가능_1개;
+        stationRepository.save(station);
+
+        // when
+        double result = reviewService.findAverageRatings(station.getStationId());
+
+        // then
+        assertThat(result).isEqualTo(0.0);
+    }
 }


### PR DESCRIPTION
## 📄 Summary
기존 로직에서는 리뷰 조회시 Double 타입으로 Repository에서 평점을 가져옵니다.
그 후에 서비스 레이어에서 double 타입으로 반환을 해서 NPE가 발생했습니다.

따라서 버그를 해결하기 위해서 해당 PR에서 작업한 내용은 다음과 같습니다.

## 버그 해결 플로우
1. 버그 해결을 위해서 Repository에서 Optional<Double>로 반환을 하도록 변경 
(Service 반환 타입을 Double로 해도 되지만, 추후에 평점 기본 값이 바뀔 수 있다고 생각해서 유연하게 Optional<Double>로 반환하도록 하였습니다.)
2. Service에서 Double로 받고 만약 평점이 존재하지 않는다면 `0.0`을 기본 값으로 설정
3. Service에서 Double로 받고 만약 평점이 존재 한다면 소숫점 한 자리까지 출력하도록 변경

## 그 외 사항
1. 조회 작업만 하는 평점 조회 기능의 경우 `Transactional(readonly = true)` 어노테이션을 추가하였습니다.

## 🕰️ Actual Time of Completion
>

## 🙋🏻 More
> 


close #507