### PR TITLE
fix: 로그인 하지 않은 회원도 사용하도록 변경한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/auth/controller/AuthArgumentResolver.java
+++ b/backend/src/main/java/com/carffeine/carffeine/auth/controller/AuthArgumentResolver.java
@@ -1,9 +1,7 @@
 package com.carffeine.carffeine.auth.controller;
 
-import com.carffeine.carffeine.auth.domain.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -14,11 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @RequiredArgsConstructor
 @Component
-public class AuthMemberResolver implements HandlerMethodArgumentResolver {
-
-    private static final String TOKEN_PREFIX = "Bearer ";
-
-    private final TokenProvider tokenProvider;
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -33,8 +27,6 @@ public class AuthMemberResolver implements HandlerMethodArgumentResolver {
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
-        String token = authorization.substring(TOKEN_PREFIX.length());
-        return tokenProvider.extract(token);
+        return (Long) request.getAttribute("loginMember");
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/auth/controller/AuthFilter.java
+++ b/backend/src/main/java/com/carffeine/carffeine/auth/controller/AuthFilter.java
@@ -29,7 +29,8 @@ public class AuthFilter extends OncePerRequestFilter {
         String authorization = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (authorization == null) {
-            sendUnauthorizedError(response, "토큰이 존재하지 않습니다");
+            request.setAttribute("loginMember", -1L);
+            filterChain.doFilter(request, response);
             return;
         }
 
@@ -39,7 +40,8 @@ public class AuthFilter extends OncePerRequestFilter {
         }
 
         String token = authorization.substring(BEARER_PREFIX.length());
-        tokenProvider.validate(token);
+        Long memberId = tokenProvider.extract(token);
+        request.setAttribute("loginMember", memberId);
         filterChain.doFilter(request, response);
     }
 

--- a/backend/src/main/java/com/carffeine/carffeine/config/WebConfig.java
+++ b/backend/src/main/java/com/carffeine/carffeine/config/WebConfig.java
@@ -1,7 +1,7 @@
 package com.carffeine.carffeine.config;
 
+import com.carffeine.carffeine.auth.controller.AuthArgumentResolver;
 import com.carffeine.carffeine.auth.controller.AuthFilter;
-import com.carffeine.carffeine.auth.controller.AuthMemberResolver;
 import com.carffeine.carffeine.web.CorsFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -17,7 +17,7 @@ import java.util.List;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    private final AuthMemberResolver authMemberResolver;
+    private final AuthArgumentResolver authArgumentResolver;
     private final AuthFilter authFilter;
 
     @Bean
@@ -34,13 +34,17 @@ public class WebConfig implements WebMvcConfigurer {
         FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
         filterRegistrationBean.setFilter(authFilter);
         filterRegistrationBean.setOrder(2);
-        filterRegistrationBean.addUrlPatterns("/stations/{stationId}/reviews");
-        filterRegistrationBean.addUrlPatterns("/reviews/{reviewId}");
+        filterRegistrationBean.addUrlPatterns("/reviews/*");
+        filterRegistrationBean.addUrlPatterns("/admin/*");
+        filterRegistrationBean.addUrlPatterns("/members/*");
+        filterRegistrationBean.addUrlPatterns("/filters/*");
+        filterRegistrationBean.addUrlPatterns("/cars/*");
+        filterRegistrationBean.addUrlPatterns("/stations/*");
         return filterRegistrationBean;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(authMemberResolver);
+        resolvers.add(authArgumentResolver);
     }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/admin/controller/AdminMemberControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/admin/controller/AdminMemberControllerTest.java
@@ -60,7 +60,7 @@ public class AdminMemberControllerTest extends MockBeanInjection {
         mockMvc.perform(get("/admin/members")
                         .param("page", "0")
                         .param("size", "2")
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isOk())
                 .andDo(customDocument("get-members",
                         requestParameters(
@@ -80,7 +80,7 @@ public class AdminMemberControllerTest extends MockBeanInjection {
     }
 
     @Test
-    void testUpdateRole() throws Exception {
+    void 회원_권한을_수정한다() throws Exception {
         // given
         MemberRoleUpdateRequest updateRequest = new MemberRoleUpdateRequest("admin");
 
@@ -88,7 +88,7 @@ public class AdminMemberControllerTest extends MockBeanInjection {
         mockMvc.perform(patch("/admin/members/{memberId}", 123L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(updateRequest))
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isNoContent())
                 .andDo(customDocument("update-member-role",
                         pathParameters(parameterWithName("memberId").description("멤버 ID")),

--- a/backend/src/test/java/com/carffeine/carffeine/admin/controller/AdminReportControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/admin/controller/AdminReportControllerTest.java
@@ -53,7 +53,7 @@ public class AdminReportControllerTest extends MockBeanInjection {
         mockMvc.perform(get("/admin/misinformation-reports")
                         .param("page", "0")
                         .param("size", "2")
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isOk())
                 .andDo(customDocument("get-misinformation-reports",
                         requestParameters(
@@ -80,7 +80,7 @@ public class AdminReportControllerTest extends MockBeanInjection {
 
         // when & then
         mockMvc.perform(get("/admin/misinformation-reports/{misinformationId}", 123L)
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isOk())
                 .andDo(customDocument("get-misinformation-detail",
                         pathParameters(parameterWithName("misinformationId").description("제보 ID")),
@@ -102,7 +102,7 @@ public class AdminReportControllerTest extends MockBeanInjection {
     @Test
     void 충전소_제보_확인으로_변경한다() throws Exception {
         mockMvc.perform(patch("/admin/misinformation-reports/{misinformationId}", 123L)
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isNoContent())
                 .andDo(customDocument("update-misinformation-checked",
                         pathParameters(parameterWithName("misinformationId").description("미스인포메이션 리포트 ID")),
@@ -124,7 +124,7 @@ public class AdminReportControllerTest extends MockBeanInjection {
         mockMvc.perform(get("/admin/fault-reports")
                         .param("page", "0")
                         .param("size", "2")
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isOk())
                 .andDo(customDocument("get-fault-reports",
                         requestParameters(

--- a/backend/src/test/java/com/carffeine/carffeine/admin/controller/AdminStationControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/admin/controller/AdminStationControllerTest.java
@@ -59,7 +59,7 @@ public class AdminStationControllerTest extends MockBeanInjection {
                         .param("page", "0")
                         .param("size", "1")
                         .param("q", "선릉역 충전소")
-                        .header(HttpHeaders.AUTHORIZATION, "token~~")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                 )
                 .andExpect(status().isOk())
                 .andDo(customDocument("get-stations",
@@ -99,7 +99,7 @@ public class AdminStationControllerTest extends MockBeanInjection {
 
         // when && then
         mockMvc.perform(get("/admin/stations/{stationId}", "station123")
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isOk())
                 .andDo(customDocument("get-station",
                         pathParameters(parameterWithName("stationId").description("충전소 ID")),
@@ -154,7 +154,7 @@ public class AdminStationControllerTest extends MockBeanInjection {
         mockMvc.perform(patch("/admin/stations/{stationId}", "station123")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                         .content(objectMapper.writeValueAsString(updateRequest))
-                        .header(HttpHeaders.AUTHORIZATION, "token~~"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isNoContent())
                 .andDo(customDocument("update-station",
                         pathParameters(parameterWithName("stationId").description("충전소 ID")),

--- a/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/car/controller/CarControllerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
@@ -97,12 +98,12 @@ class CarControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/cars")
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(AUTHORIZATION, "Bearer token~~")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON)
                 ).andExpect(status().isCreated())
                 .andDo(customDocument("save_all_cars",
-                        requestHeaders(headerWithName(org.springframework.http.HttpHeaders.AUTHORIZATION).description("인증 토큰")),
+                        requestHeaders(headerWithName(AUTHORIZATION).description("인증 토큰")),
                         requestFields(
                                 fieldWithPath("cars[0].name").type(JsonFieldType.STRING).description("차량 이름"),
                                 fieldWithPath("cars[0].vintage").type(JsonFieldType.STRING).description("차량 연식"),
@@ -127,7 +128,7 @@ class CarControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(delete("/cars/{carId}", 1L)
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(AUTHORIZATION, "Bearer token~~")
                 ).andExpect(status().isNoContent())
                 .andDo(customDocument("delete_car",
                         requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
@@ -182,7 +183,7 @@ class CarControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/cars/{carId}/filters", 1L)
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(AUTHORIZATION, "Bearer token~~")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 )

--- a/backend/src/test/java/com/carffeine/carffeine/filter/controller/FilterControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/filter/controller/FilterControllerTest.java
@@ -97,7 +97,7 @@ public class FilterControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/filters")
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(filtersRequest))
                 ).andExpect(status().isCreated())
@@ -123,7 +123,7 @@ public class FilterControllerTest extends MockBeanInjection {
     void 필터를_제거한다() throws Exception {
         // then
         mockMvc.perform(RestDocumentationRequestBuilders.delete("/filters/{filterName}", "filterName")
-                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~"))
                 .andExpect(status().isNoContent())
                 .andDo(customDocument("delete_filter",
                         requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),

--- a/backend/src/test/java/com/carffeine/carffeine/helper/MockBeanInjection.java
+++ b/backend/src/test/java/com/carffeine/carffeine/helper/MockBeanInjection.java
@@ -3,7 +3,7 @@ package com.carffeine.carffeine.helper;
 import com.carffeine.carffeine.admin.service.AdminMemberService;
 import com.carffeine.carffeine.admin.service.AdminReportService;
 import com.carffeine.carffeine.admin.service.AdminStationService;
-import com.carffeine.carffeine.auth.controller.AuthMemberResolver;
+import com.carffeine.carffeine.auth.controller.AuthArgumentResolver;
 import com.carffeine.carffeine.auth.domain.TokenProvider;
 import com.carffeine.carffeine.auth.service.AuthService;
 import com.carffeine.carffeine.auth.service.OAuthRequester;
@@ -27,7 +27,7 @@ public class MockBeanInjection {
     @MockBean
     protected ReportService reportService;
     @MockBean
-    protected AuthMemberResolver authMemberResolver;
+    protected AuthArgumentResolver authArgumentResolver;
     @MockBean
     protected TokenProvider tokenProvider;
     @MockBean

--- a/backend/src/test/java/com/carffeine/carffeine/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/member/controller/MemberControllerTest.java
@@ -67,7 +67,7 @@ class MemberControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(get("/members/{memberId}/filters", 1L)
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                 ).andExpect(status().isOk())
                 .andDo(customDocument("find_member_filters",
                                 requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
@@ -105,7 +105,7 @@ class MemberControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/members/{memberId}/filters", 1L)
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(filtersRequest))
                 ).andExpect(status().isOk())
@@ -139,7 +139,7 @@ class MemberControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(get("/members/me")
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                 ).andExpect(status().isOk())
                 .andDo(customDocument("find_member_car",
                                 requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("인증 토큰")),
@@ -164,7 +164,7 @@ class MemberControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/members/{memberId}/cars", 1L)
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(carRequest))
                 ).andExpect(status().isCreated())

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/report/ReportControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/report/ReportControllerTest.java
@@ -65,7 +65,7 @@ class ReportControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/stations/{stationId}/reports", station.getStationId())
-                        .header(HttpHeaders.AUTHORIZATION, memberId))
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
 
                 .andExpect(status().isNoContent())
                 .andDo(customDocument("save-report",
@@ -94,7 +94,7 @@ class ReportControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/stations/{stationId}/misinformation-reports", station.getStationId())
-                        .header(HttpHeaders.AUTHORIZATION, memberId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request))
                 )
@@ -122,8 +122,7 @@ class ReportControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(get("/stations/{stationId}/reports/me", station.getStationId())
-                        .header(HttpHeaders.AUTHORIZATION, memberId))
-
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token"))
                 .andExpect(status().isOk())
                 .andDo(customDocument("duplicate-report",
                                 requestHeaders(headerWithName("Authorization").description("회원 id.")),

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/review/ReplyControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/review/ReplyControllerTest.java
@@ -72,7 +72,7 @@ public class ReplyControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/reviews/{reviewId}/replies", review.getId())
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token~~")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(jsonData)

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/review/ReviewControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/review/ReviewControllerTest.java
@@ -72,7 +72,7 @@ public class ReviewControllerTest extends MockBeanInjection {
 
         // then
         mockMvc.perform(post("/stations/{stationId}/reviews", station.getStationId())
-                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer token")
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(jsonData)

--- a/backend/src/test/java/com/carffeine/carffeine/station/integration/review/ReviewIntegrationTestFixture.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/integration/review/ReviewIntegrationTestFixture.java
@@ -6,6 +6,7 @@ import com.carffeine.carffeine.station.service.review.dto.CreateReviewRequest;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 
 import java.util.HashMap;
@@ -16,7 +17,7 @@ public class ReviewIntegrationTestFixture {
 
     public static ExtractableResponse<Response> 댓글을_등록한다(CreateReviewRequest request, String token, Station station) {
         return RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + token)
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token)
                 .body(getParams(request))
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()


### PR DESCRIPTION
## 📄 Summary
> 현재 로그인 하지 않은 사용자도 확인할 수 있는 기능에서 로그인을 하지 않았다면 토큰 복호화 과정에서 에러가 발생하고 있어서, 로그인하지 않은 회원이면 -1 로 할당하고 복호화 과정을 skip 할 수있도록 했습니다.

## 🕰️ Actual Time of Completion
> 1시간

## 🙋🏻 More
> 


close #500