### PR TITLE
fix: 공공 데이터에서 받아온 시간과 조회하는 시간이 다른 문제를 해결한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/ChargerStatusCustomRepositoryImpl.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/ChargerStatusCustomRepositoryImpl.java
@@ -39,13 +39,13 @@ public class ChargerStatusCustomRepositoryImpl implements ChargerStatusCustomRep
         namedParameterJdbcTemplate.batchUpdate(sql, sqlParameterSources);
     }
 
-    private MapSqlParameterSource changeToSqlParameterSource(ChargerStatus item) {
+    private MapSqlParameterSource changeToSqlParameterSource(ChargerStatus status) {
         LocalDateTime now = LocalDateTime.now();
         return new MapSqlParameterSource()
-                .addValue("stationId", item.getStationId())
-                .addValue("chargerId", item.getChargerId())
-                .addValue("latestUpdateTime", item.getLatestUpdateTime())
-                .addValue("chargerCondition", item.getChargerCondition().name())
+                .addValue("stationId", status.getStationId())
+                .addValue("chargerId", status.getChargerId())
+                .addValue("latestUpdateTime", status.getLatestUpdateTime())
+                .addValue("chargerCondition", status.getChargerCondition().name())
                 .addValue("createdAt", now)
                 .addValue("updatedAt", now);
     }

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/charger/dto/ChargerStateRequest.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/charger/dto/ChargerStateRequest.java
@@ -32,6 +32,6 @@ public record ChargerStateRequest(
             return null;
         }
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-        return LocalDateTime.parse(input, formatter);
+        return LocalDateTime.parse(input, formatter).minusHours(9);
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/station/dto/StationInfoRequest.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/station/dto/StationInfoRequest.java
@@ -105,7 +105,7 @@ public record StationInfoRequest(
         }
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
-        return LocalDateTime.parse(input, formatter);
+        return LocalDateTime.parse(input, formatter).minusHours(9);
     }
 
     private BigDecimal parseBigDecimalFromString(String input) {


### PR DESCRIPTION
[#586]

## 📄 Summary
> 현재 java는 asia/seoul 기준, 공공 데이터도 asia/seoul 기준, 하지만 mysql은 utc 기준입니다.
일단 최대한 빠르게 해결할 방법은 공공 데이터 api의 시간을 -9해서 저장하는 방법으로 해결하고 추후 시간에 대한 설정을 좀 더 고도화 해보겠습니다.
아직은 데이터가 이상하게 보일 수도 있는데 9시간 지나면 대부분의 데이터가 괜찮아질 것입니다.

## 🕰️ Actual Time of Completion
> 10분

## 🙋🏻 More
> 


close #586