### PR TITLE
fix: 배포시 favicon이 보이지 않는 문제 개선한다

### DIFF
--- a/frontend/webpack.config.dev.js
+++ b/frontend/webpack.config.dev.js
@@ -63,9 +63,9 @@ module.exports = function () {
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: './public/index.html',
+        template: path.join(__dirname, './public/index.html'),
         hash: true,
-        favicon: './public/favicon.ico',
+        favicon: path.join(__dirname, './public/favicon.ico'),
       }),
       new DotEnv(),
       new CopyWebpackPlugin({

--- a/frontend/webpack.config.prod.js
+++ b/frontend/webpack.config.prod.js
@@ -60,9 +60,9 @@ module.exports = function () {
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: './public/index.html',
+        template: path.join(__dirname, './public/index.html'),
         hash: true,
-        favicon: './public/favicon.ico',
+        favicon: path.join(__dirname, './public/favicon.ico'),
       }),
       new DotEnv(),
     ],


### PR DESCRIPTION
[#589]

## 📄 Summary
>  ~~배포시 favicon이 보이지 않는 문제 개선한다.
로컬에서는 잘 보이기 때문에 배포 후 확인이 필요하다.~~

이미 파비콘이 잘 보이는 것을 확인하여 PR을 닫습니다
<img width="114" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/9874240d-1386-4fbc-9590-16f66c661d84">


## 🕰️ Actual Time of Completion
> 5분

## 🙋🏻 More
> 


close #589