### PR TITLE
feat: 구글 지도 랜드마크 클릭 못하게 하는 기능 추가한다

### DIFF
--- a/frontend/src/stores/google-maps/googleMapStore.ts
+++ b/frontend/src/stores/google-maps/googleMapStore.ts
@@ -25,6 +25,7 @@ export const getGoogleMapStore = (() => {
         center: initialCenter,
         zoom: INITIAL_ZOOM_SIZE,
         disableDefaultUI: true,
+        clickableIcons: false,
         mapId: '92cb7201b7d43b21',
         minZoom: 8,
         maxZoom: 20,


### PR DESCRIPTION
[#606]

## 📄 Summary
> 구글 지도에서 랜드마크 클릭시 해당 랜드마크 정보가 마커 위에 나오는 것이 기본값이다. 우리 서비스에서는 오히려 사용자 경험을 해치는 기능이기 때문에 이 기능을 없애기로 했다.

## 🕰️ Actual Time of Completion
> 5분

## 🙋🏻 More
> 


close #606