### PR TITLE
refactor: 혼잡도 관련 코드 리팩토링을 한다

### DIFF
--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/congestion/CongestionController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/congestion/CongestionController.java
@@ -17,7 +17,7 @@ public class CongestionController {
 
     @GetMapping("/stations/{stationId}/statistics")
     public ResponseEntity<StatisticsResponse> showCongestionStatistics(@PathVariable String stationId) {
-        StatisticsResponse statisticsResponse = congestionService.calculateCongestion(new StatisticsRequest(stationId));
+        StatisticsResponse statisticsResponse = congestionService.showCongestionStatistics(new StatisticsRequest(stationId));
         return ResponseEntity.ok(statisticsResponse);
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestion.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestion.java
@@ -5,6 +5,7 @@ import com.carffeine.carffeine.station.config.RequestPeriodConverter;
 import com.carffeine.carffeine.station.domain.charger.Charger;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,8 +27,12 @@ import java.time.DayOfWeek;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
+@EqualsAndHashCode(of = {"id"}, callSuper = false)
 @Table(name = "periodic_congestion")
 public class PeriodicCongestion extends BaseEntity {
+
+    private static final int DEFAULT_COUNT = 0;
+    private static final double DEFAULT_CONGESTIONS = 0;
 
     @Id
     private String id;
@@ -73,9 +78,18 @@ public class PeriodicCongestion extends BaseEntity {
         this.chargerId = chargerId;
     }
 
-    public static PeriodicCongestion of(DayOfWeek dayOfWeek, RequestPeriod startTime, int useCount, int totalCount, String stationId, String chargerId) {
+    public static PeriodicCongestion createDefault(DayOfWeek dayOfWeek, RequestPeriod startTime, String stationId, String chargerId) {
         String id = IdGenerator.generateId(dayOfWeek, startTime, stationId, chargerId);
-        double congestion = (double) useCount / totalCount;
-        return new PeriodicCongestion(id, dayOfWeek, startTime, useCount, totalCount, congestion, stationId, chargerId);
+
+        return new PeriodicCongestion(
+                id,
+                dayOfWeek,
+                startTime,
+                DEFAULT_COUNT,
+                DEFAULT_COUNT,
+                DEFAULT_CONGESTIONS,
+                stationId,
+                chargerId
+        );
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestionCustomRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestionCustomRepository.java
@@ -11,5 +11,5 @@ public interface PeriodicCongestionCustomRepository {
 
     void updateUsingCount(DayOfWeek dayOfWeek, RequestPeriod period, List<ChargerStatus> usingChargers);
 
-    void saveAll(List<PeriodicCongestion> periodicCongestions);
+    void saveAllIfNotExist(List<PeriodicCongestion> periodicCongestions);
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestionRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/domain/congestion/PeriodicCongestionRepository.java
@@ -2,14 +2,9 @@ package com.carffeine.carffeine.station.domain.congestion;
 
 import org.springframework.data.repository.Repository;
 
-import java.time.DayOfWeek;
 import java.util.List;
 
 public interface PeriodicCongestionRepository extends Repository<PeriodicCongestion, String> {
-
-    List<PeriodicCongestion> findAllByDayOfWeekAndStartTime(DayOfWeek dayOfWeek, RequestPeriod startTime);
-
-    PeriodicCongestion save(PeriodicCongestion periodicCongestion);
 
     List<PeriodicCongestion> findAllByStationId(String stationId);
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/congestion/CongestionService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/congestion/CongestionService.java
@@ -31,7 +31,7 @@ public class CongestionService {
     private final PeriodicCongestionRepository periodicCongestionRepository;
     private final ChargerRepository chargerRepository;
 
-    public StatisticsResponse calculateCongestion(StatisticsRequest statisticsRequest) {
+    public StatisticsResponse showCongestionStatistics(StatisticsRequest statisticsRequest) {
         String stationId = statisticsRequest.stationId();
 
         List<PeriodicCongestion> congestions = periodicCongestionRepository.findAllByStationId(stationId);

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,22 +1,22 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/charge?useSSL=false&serverTimezone=UTC&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:13306/charge?useSSL=false&serverTimezone=UTC&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
   flyway:
-    enabled: false
-    baseline-on-migrate: false
+    enabled: true
+    baseline-on-migrate: true
   jpa:
     hibernate:
       ddl-auto: validate
     database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        format_sql: false
+        show_sql: false
 initialize-charge:
   enabled: false
 
 scheduling:
-  enabled: true
+  enabled: false

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,12 +1,12 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:13306/charge?useSSL=false&serverTimezone=UTC&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:3306/charge?useSSL=false&serverTimezone=UTC&useUnicode=true&characterEncoding=utf8&allowPublicKeyRetrieval=true
     username: root
     password: root
     driver-class-name: com.mysql.cj.jdbc.Driver
   flyway:
-    enabled: true
-    baseline-on-migrate: true
+    enabled: false
+    baseline-on-migrate: false
   jpa:
     hibernate:
       ddl-auto: validate
@@ -19,4 +19,4 @@ initialize-charge:
   enabled: false
 
 scheduling:
-  enabled: false
+  enabled: true

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/congestion/CongestionControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/congestion/CongestionControllerTest.java
@@ -42,7 +42,7 @@ class CongestionControllerTest extends MockBeanInjection {
         // given
         String stationId = "1";
 
-        given(congestionService.calculateCongestion(any()))
+        given(congestionService.showCongestionStatistics(any()))
                 .willReturn(
                         new StatisticsResponse(
                                 "1",

--- a/backend/src/test/java/com/carffeine/carffeine/station/domain/congestion/RequestPeriodTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/domain/congestion/RequestPeriodTest.java
@@ -18,6 +18,6 @@ class RequestPeriodTest {
         RequestPeriod result = RequestPeriod.from(input);
 
         // then
-        assertThat(result).isSameAs(RequestPeriod.from(input));
+        assertThat(result.getSection()).isEqualTo(input * 100);
     }
 }

--- a/backend/src/test/java/com/carffeine/carffeine/station/infrastructure/repository/PeriodicCongestionCustomRepositoryImplTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/infrastructure/repository/PeriodicCongestionCustomRepositoryImplTest.java
@@ -1,0 +1,101 @@
+package com.carffeine.carffeine.station.infrastructure.repository;
+
+import com.carffeine.carffeine.station.domain.charger.ChargerStatus;
+import com.carffeine.carffeine.station.domain.congestion.PeriodicCongestion;
+import com.carffeine.carffeine.station.domain.congestion.PeriodicCongestionRepository;
+import com.carffeine.carffeine.station.domain.congestion.RequestPeriod;
+import com.carffeine.carffeine.station.domain.station.Station;
+import com.carffeine.carffeine.station.domain.station.StationRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+import static com.carffeine.carffeine.station.fixture.station.StationFixture.선릉역_충전소_충전기_2개_사용가능_1개;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+@SuppressWarnings("NonAsciiCharacters")
+@SpringBootTest
+class PeriodicCongestionCustomRepositoryImplTest {
+
+    @Autowired
+    private StationRepository stationRepository;
+
+    @Autowired
+    private PeriodicCongestionCustomRepositoryImpl periodicCongestionCustomRepository;
+
+    @Autowired
+    private PeriodicCongestionRepository periodicCongestionRepository;
+
+    @Test
+    void DB에_혼잡도_정보가_없다면_저장한다() {
+        // given
+        Station savedStation = stationRepository.save(선릉역_충전소_충전기_2개_사용가능_1개);
+        periodicCongestionCustomRepository.saveAllIfNotExist(List.of(
+                PeriodicCongestion.createDefault(DayOfWeek.MONDAY, RequestPeriod.ONE, savedStation.getStationId(), "01")
+        ));
+
+        List<PeriodicCongestion> periodicCongestions = List.of(
+                PeriodicCongestion.createDefault(DayOfWeek.MONDAY, RequestPeriod.ONE, savedStation.getStationId(), "01"),
+                PeriodicCongestion.createDefault(DayOfWeek.MONDAY, RequestPeriod.ONE, savedStation.getStationId(), "02")
+        );
+
+        // when
+        periodicCongestionCustomRepository.saveAllIfNotExist(periodicCongestions);
+
+        // then
+        List<PeriodicCongestion> result = periodicCongestionRepository.findAllByStationId(savedStation.getStationId());
+        assertSoftly(softly -> {
+            softly.assertThat(result.size()).isEqualTo(2);
+            softly.assertThat(result.get(0).getStationId()).isEqualTo(savedStation.getStationId());
+            softly.assertThat(result.get(1).getStationId()).isEqualTo(savedStation.getStationId());
+        });
+    }
+
+    @Test
+    void 요일과_시간을_기준으로_total_count를_업데이트한다() {
+        // given
+        Station savedStation = stationRepository.save(선릉역_충전소_충전기_2개_사용가능_1개);
+        periodicCongestionCustomRepository.saveAllIfNotExist(List.of(
+                PeriodicCongestion.createDefault(DayOfWeek.MONDAY, RequestPeriod.ONE, savedStation.getStationId(), "01")
+        ));
+
+        // when
+        periodicCongestionCustomRepository.updateTotalCountByPeriod(DayOfWeek.MONDAY, RequestPeriod.ONE);
+
+        // then
+        PeriodicCongestion result = periodicCongestionRepository.findAllByStationId(savedStation.getStationId()).get(0);
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalCount()).isEqualTo(1);
+            softly.assertThat(result.getCongestion()).isEqualTo(0.0);
+        });
+    }
+
+    @Test
+    void 요일과_시간을_기준으로_사용중인_충전기에_대해서_count를_업데이트한다() {
+        // given
+        Station savedStation = stationRepository.save(선릉역_충전소_충전기_2개_사용가능_1개);
+
+        periodicCongestionCustomRepository.saveAllIfNotExist(List.of(
+                PeriodicCongestion.createDefault(DayOfWeek.MONDAY, RequestPeriod.ONE, savedStation.getStationId(), "01"),
+                PeriodicCongestion.createDefault(DayOfWeek.MONDAY, RequestPeriod.ONE, savedStation.getStationId(), "02")
+        ));
+
+        ChargerStatus usingChargerStatus = savedStation.getChargers().get(1).getChargerStatus();
+
+        // when
+        periodicCongestionCustomRepository.updateUsingCount(DayOfWeek.MONDAY, RequestPeriod.ONE, List.of(usingChargerStatus));
+
+        // then
+        PeriodicCongestion result = periodicCongestionRepository.findAllByStationId(savedStation.getStationId()).get(1);
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalCount()).isEqualTo(0);
+            softly.assertThat(result.getUseCount()).isEqualTo(1);
+        });
+    }
+}

--- a/backend/src/test/java/com/carffeine/carffeine/station/service/congestion/CongestionServiceTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/service/congestion/CongestionServiceTest.java
@@ -33,7 +33,7 @@ class CongestionServiceTest {
     @Test
     void 상태값이_없는_데이터일_경우_음수가_반환된다() {
         StatisticsRequest statisticsRequest = new StatisticsRequest("ME174003");
-        StatisticsResponse statisticsResponse = congestionService.calculateCongestion(statisticsRequest);
+        StatisticsResponse statisticsResponse = congestionService.showCongestionStatistics(statisticsRequest);
 
         CongestionResponse expected = getExpected();
 


### PR DESCRIPTION
## 📄 Summary
기존 이슈인 [혼잡도 조회 기능의 성능을 개선한다 #655 ]를 진행하기 앞서 혼잡도 관련 코드를 리팩토링 했습니다.

### 버그
먼저 현재 혼잡도 업데이트를 해주는 Repository 로직에 문제가 있습니다.

totalCount를 +1 해주는 부분에서 추가적으로 SET use_count / total_count또한 해주게 됩니다.
그런데 만약 새롭게 생성된 객체라면 total_count & count == 0의 기본값을 가지게 됩니다.
이 경우 Division을 하게되면 0/0이 되므로 Mysql에서 Exception이 발생합니다. (작동은 되긴 합니다)
따라서 이 부분의 쿼리를 CASE WHEN total_count = 0 THEN 0 ELSE use_count / total_count END와 같이 변경 했습니다.

### 리팩토링
- 현재 혼잡도 관련 코드의 가독성이 좋지 않아서 네이밍과 메서드 분리 및 객체가 할 수 있는 일은 객체가 할 수 있도록 변경했습니다.
- 안쓰는 메서드가 있어서 제거하였습니다.

### 테스트 누락
- 혼잡도 관련 Repository의 테스트 코드가 누락되어 있어서 채워놨습니다.

## 🕰️ Actual Time of Completion
> 1시간

## 🙋🏻 More
> 


close #660