### PR TITLE
fix: index가 아닌 다른 uri를 찾을 수 없는 에러를 해결한다

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -14,7 +14,7 @@ RUN yarn build
 FROM nginx
 
 RUN rm -rf /etc/nginx/conf.d
-COPY conf /etc/nginx
+COPY nginx /etc/nginx
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/node:18-alpine as builder
+FROM arm64v8/node:18-alpine AS builder
 
 WORKDIR /app
 
@@ -12,6 +12,9 @@ COPY . .
 RUN yarn build
 
 FROM nginx
+
+RUN rm -rf /etc/nginx/conf.d
+COPY conf /etc/nginx
 
 COPY --from=builder /app/dist /usr/share/nginx/html
 

--- a/frontend/nginx/conf.d/react.conf
+++ b/frontend/nginx/conf.d/react.conf
@@ -1,0 +1,7 @@
+server {
+    root /usr/share/nginx/html;
+    location / {
+        index index.html;
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## 📄 Summary
> nginx의 기본 설정이 다른 uri를 찾을 수 없도록 되어 있어 새로운 설정파일과 함께 docker build를 하도록 변경했습니다.

## 🕰️ Actual Time of Completion
> 10분

## 🙋🏻 More
> 


close #663