### PR TITLE
fix: 모바일에서 충전소 리스트가 열리지 않는 오류 수정

### DIFF
--- a/frontend/src/components/ui/StationList/StationListWindow.tsx
+++ b/frontend/src/components/ui/StationList/StationListWindow.tsx
@@ -1,10 +1,6 @@
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { css } from 'styled-components';
 
-import { useExternalValue } from '@utils/external-state';
-
-import { selectedStationIdStore } from '@stores/selectedStationStore';
-
 import Button from '@common/Button';
 import FlexBox from '@common/FlexBox';
 import Text from '@common/Text';
@@ -17,12 +13,7 @@ import { MOBILE_BREAKPOINT } from '@constants';
 import StationList from './StationList';
 
 const StationListWindow = () => {
-  const selectedStationId = useExternalValue(selectedStationIdStore);
   const { closeBasePanel } = useNavigationBar();
-
-  if (selectedStationId !== null) {
-    closeBasePanel();
-  }
 
   return (
     <FlexBox css={[containerCss]} nowrap>


### PR DESCRIPTION
## 📄 Summary
StationList가 좌측 패널로 사용될 때 작성했던 코드의 잔재가 남아있어 그 부분 때문에 발생한 오류였습니다.

오류 발생 원인
- StationList가 좌측 패널로 사용될 때 충전소를 선택하면 StationList를 강제로 닫아버리는 로직이 존재했음
- 네비게이터에서 StationList가 패널 메뉴에서 사라짐
- 네비게이터에서 사라진 이후 모바일 대응을 하다가 StationList가 다시 모바일에서 사용됨
- 강제로 닫아버리는 로직 때문에 마커를 클릭한 이후 StationList를 열려고 시도하면 강제로 닫아버리는 로직에 의해 리스트가 닫히는 버그가 생김


해결 방법
- StationList를 강제로 닫아버리는 로직은 이제 사용하지 않기 때문에 이 로직을 수행하던 부분을 지워줌

## 🕰️ Actual Time of Completion
> 30분

## 🙋🏻 More
> 


close #666