### PR TITLE
refactor: 충전소 및 지역 검색 시 충전기가 아닌 충전소 기준으로 조회되도록 변경한다

### DIFF
--- a/backend/src/docs/asciidoc/station.adoc
+++ b/backend/src/docs/asciidoc/station.adoc
@@ -63,3 +63,15 @@ include::{snippets}/station-controller-test/stationSummary/request-parameters.ad
 
 include::{snippets}/station-controller-test/stationSummary/http-response.adoc[]
 include::{snippets}/station-controller-test/stationSummary/response-fields.adoc[]
+
+== 검색어를 입력하면 관련 충전소를 조회한다 (/stations/search)
+
+=== Request
+
+include::{snippets}/station-controller-test/searchStations/http-request.adoc[]
+include::{snippets}/station-controller-test/searchStations/request-parameters.adoc[]
+
+=== Response
+
+include::{snippets}/station-controller-test/searchStations/http-response.adoc[]
+include::{snippets}/station-controller-test/searchStations/response-fields.adoc[]

--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
@@ -38,8 +38,9 @@ public class StationController {
     @GetMapping("/stations/search")
     public ResponseEntity<StationsSearchResponse> searchStations(@RequestParam(value = "q") String query,
                                                                  @RequestParam(value = "scope") Set<String> scope,
-                                                                 @RequestParam(value = "limit") int limit) {
-        StationsSearchResponse stationSearchResponse = stationQueryService.searchStations(query, scope, limit);
+                                                                 @RequestParam(value = "page", defaultValue = "1") int page,
+                                                                 @RequestParam(value = "limit", defaultValue = "12") int limit) {
+        StationsSearchResponse stationSearchResponse = stationQueryService.searchStations(query, scope, page, limit);
         return ResponseEntity.ok(stationSearchResponse);
     }
 

--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
@@ -38,9 +38,8 @@ public class StationController {
     @GetMapping("/stations/search")
     public ResponseEntity<StationsSearchResponse> searchStations(@RequestParam(value = "q") String query,
                                                                  @RequestParam(value = "scope") Set<String> scope,
-                                                                 @RequestParam(value = "page", required = false, defaultValue = "1") int page,
                                                                  @RequestParam(value = "limit", required = false, defaultValue = "12") int limit) {
-        StationsSearchResponse stationSearchResponse = stationQueryService.searchStations(query, scope, page, limit);
+        StationsSearchResponse stationSearchResponse = stationQueryService.searchStations(query, scope, limit);
         return ResponseEntity.ok(stationSearchResponse);
     }
 

--- a/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/controller/station/StationController.java
@@ -38,7 +38,7 @@ public class StationController {
     @GetMapping("/stations/search")
     public ResponseEntity<StationsSearchResponse> searchStations(@RequestParam(value = "q") String query,
                                                                  @RequestParam(value = "scope") Set<String> scope,
-                                                                 @RequestParam(value = "limit", required = false, defaultValue = "12") int limit) {
+                                                                 @RequestParam(value = "limit") int limit) {
         StationsSearchResponse stationSearchResponse = stationQueryService.searchStations(query, scope, limit);
         return ResponseEntity.ok(stationSearchResponse);
     }

--- a/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/StationQueryRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/StationQueryRepository.java
@@ -178,21 +178,19 @@ public class StationQueryRepository {
     }
 
     public StationSearchResult findSearchResult(String query, int limit) {
-        List<StationInfo> stations = jpaQueryFactory.selectFrom(station)
+        List<StationInfo> stations = jpaQueryFactory
+                .select(constructor(StationInfo.class,
+                        station.stationId,
+                        station.stationName,
+                        station.address,
+                        station.latitude.value,
+                        station.longitude.value))
+                .from(station)
                 .where(station.stationName.contains(query)
                         .or(station.address.contains(query)))
-                .limit(limit)
                 .orderBy(station.stationId.asc())
-                .transform(
-                        groupBy(station.stationId)
-                                .list(constructor(StationInfo.class,
-                                        station.stationId,
-                                        station.stationName,
-                                        station.address,
-                                        station.latitude.value,
-                                        station.longitude.value
-                                ))
-                );
+                .limit(limit)
+                .fetch();
 
         Long totalCount = jpaQueryFactory.select(station.stationId.count())
                 .from(station)

--- a/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/StationQueryRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/StationQueryRepository.java
@@ -177,13 +177,10 @@ public class StationQueryRepository {
         return charger.capacity.in(capacities);
     }
 
-    public StationSearchResult findSearchResult(String query, int page, int limit) {
+    public StationSearchResult findSearchResult(String query, int limit) {
         List<StationInfo> stations = jpaQueryFactory.selectFrom(station)
-                .innerJoin(charger)
-                .on(charger.stationId.eq(station.stationId))
                 .where(station.stationName.contains(query)
                         .or(station.address.contains(query)))
-                .offset((long) (page - 1) * limit)
                 .limit(limit)
                 .orderBy(station.stationId.asc())
                 .transform(
@@ -198,9 +195,7 @@ public class StationQueryRepository {
                                 ))
                 );
 
-        Long totalCount = jpaQueryFactory.select(
-                        station.stationId.count()
-                )
+        Long totalCount = jpaQueryFactory.select(station.stationId.count())
                 .from(station)
                 .where(station.stationName.contains(query)
                         .or(station.address.contains(query)))

--- a/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/StationQueryRepository.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/StationQueryRepository.java
@@ -188,7 +188,6 @@ public class StationQueryRepository {
                                 .list(constructor(StationInfo.class,
                                         station.stationId,
                                         station.stationName,
-                                        list(charger.type),
                                         station.address,
                                         station.latitude.value,
                                         station.longitude.value

--- a/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/dto/StationInfo.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/infrastructure/repository/station/dto/StationInfo.java
@@ -1,14 +1,10 @@
 package com.carffeine.carffeine.station.infrastructure.repository.station.dto;
 
-import com.carffeine.carffeine.station.domain.charger.ChargerType;
-
 import java.math.BigDecimal;
-import java.util.List;
 
 public record StationInfo(
         String stationId,
         String stationName,
-        List<ChargerType> chargerTypes,
         String address,
         BigDecimal latitude,
         BigDecimal longitude

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/station/StationQueryService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/station/StationQueryService.java
@@ -60,7 +60,7 @@ public class StationQueryService {
         return stationQueryRepository.findStationsSummary(stationIds);
     }
 
-    public StationsSearchResponse searchStations(String query, Set<String> scope, int limit) {
+    public StationsSearchResponse searchStations(String query, Set<String> scope, int page, int limit) {
         StationSearchResult searchResult = stationQueryRepository.findSearchResult(query, limit);
         List<StationSearchResponse> stationByScope = stationsToScope(searchResult.stations(), scope);
         return new StationsSearchResponse(searchResult.totalCount(), stationByScope);

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/station/StationQueryService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/station/StationQueryService.java
@@ -60,8 +60,8 @@ public class StationQueryService {
         return stationQueryRepository.findStationsSummary(stationIds);
     }
 
-    public StationsSearchResponse searchStations(String query, Set<String> scope, int page, int limit) {
-        StationSearchResult searchResult = stationQueryRepository.findSearchResult(query, page, limit);
+    public StationsSearchResponse searchStations(String query, Set<String> scope, int limit) {
+        StationSearchResult searchResult = stationQueryRepository.findSearchResult(query, limit);
         List<StationSearchResponse> stationByScope = stationsToScope(searchResult.stations(), scope);
         return new StationsSearchResponse(searchResult.totalCount(), stationByScope);
     }

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/station/StationQueryService.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/station/StationQueryService.java
@@ -86,22 +86,7 @@ public class StationQueryService {
         if (scope.contains("longitude")) {
             builder.longitude(station.longitude());
         }
-        if (scope.contains("speed")) {
-            List<String> speed = station.chargerTypes().stream()
-                    .map(ChargerType::getDefaultCapacity)
-                    .map(this::parseToChargerSpeed)
-                    .distinct()
-                    .toList();
-            builder.speed(speed);
-        }
         builder.stationId(station.stationId());
         return builder.build();
-    }
-
-    private String parseToChargerSpeed(BigDecimal capacity) {
-        if (capacity.compareTo(BigDecimal.valueOf(QUICK_CAPACITY)) >= 0) {
-            return QUICK;
-        }
-        return STANDARD;
     }
 }

--- a/backend/src/main/java/com/carffeine/carffeine/station/service/station/dto/StationSearchResponse.java
+++ b/backend/src/main/java/com/carffeine/carffeine/station/service/station/dto/StationSearchResponse.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
 import java.math.BigDecimal;
-import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Builder
 public record StationSearchResponse(
         String stationId,
         String stationName,
-        List<String> speed,
         String address,
         BigDecimal latitude,
         BigDecimal longitude

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
@@ -190,7 +190,7 @@ class StationControllerTest extends MockBeanInjection {
 
     @Test
     void 충전소를_검색한다() throws Exception {
-        when(stationQueryService.searchStations(any(), any(), anyInt(), anyInt()))
+        when(stationQueryService.searchStations(any(), any(), anyInt()))
                 .thenReturn(new StationsSearchResponse(
                         2L,
                         List.of(
@@ -218,14 +218,13 @@ class StationControllerTest extends MockBeanInjection {
                         )
                 ));
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&page=1&scope=stationName&scope=address&scope=speed&scope=latitude&scope=longitude"))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&scope=stationId&scope=stationName&scope=address&scope=latitude&scope=longitude"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCount").value(2))
                 .andExpect(jsonPath("$.stations", hasSize(2)))
                 .andDo(customDocument("searchStations",
                         requestParameters(
                                 parameterWithName("q").description("검색어"),
-                                parameterWithName("page").description("페이지 번호"),
                                 parameterWithName("scope").description("검색 범위")
                         ),
                         responseFields(

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
@@ -211,14 +211,15 @@ class StationControllerTest extends MockBeanInjection {
                         )
                 ));
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&scope=stationId&scope=stationName&scope=address&scope=latitude&scope=longitude"))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&scope=stationId&scope=stationName&scope=address&scope=latitude&scope=longitude&limit=12"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCount").value(2))
                 .andExpect(jsonPath("$.stations", hasSize(2)))
                 .andDo(customDocument("searchStations",
                         requestParameters(
                                 parameterWithName("q").description("검색어"),
-                                parameterWithName("scope").description("검색 범위")
+                                parameterWithName("scope").description("검색 범위"),
+                                parameterWithName("limit").description("검색 결과 개수")
                         ),
                         responseFields(
                                 fieldWithPath("totalCount").type(JsonFieldType.NUMBER).description("검색 결과 전체 개수"),

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
@@ -197,10 +197,6 @@ class StationControllerTest extends MockBeanInjection {
                                 new StationSearchResponse(
                                         "stationId",
                                         "잠실 충전소",
-                                        List.of(
-                                                "QUICK",
-                                                "STANDARD"
-                                        ),
                                         "address",
                                         BigDecimal.valueOf(37.123456),
                                         BigDecimal.valueOf(127.123456)
@@ -208,9 +204,6 @@ class StationControllerTest extends MockBeanInjection {
                                 new StationSearchResponse(
                                         "stationId2",
                                         "선릉 충전소",
-                                        List.of(
-                                                "QUICK"
-                                        ),
                                         "address2",
                                         BigDecimal.valueOf(37.123456),
                                         BigDecimal.valueOf(127.123456)
@@ -234,8 +227,7 @@ class StationControllerTest extends MockBeanInjection {
                                 fieldWithPath("stations[].stationName").type(JsonFieldType.STRING).description("충전소 이름"),
                                 fieldWithPath("stations[].address").type(JsonFieldType.STRING).description("충전소 주소"),
                                 fieldWithPath("stations[].latitude").type(JsonFieldType.NUMBER).description("위도"),
-                                fieldWithPath("stations[].longitude").type(JsonFieldType.NUMBER).description("경도"),
-                                fieldWithPath("stations[].speed").type(JsonFieldType.ARRAY).description("충전소에 포함되어있는 급속 완속 충전기 종류")
+                                fieldWithPath("stations[].longitude").type(JsonFieldType.NUMBER).description("경도")
                         )
                 ));
     }

--- a/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/controller/station/StationControllerTest.java
@@ -190,7 +190,7 @@ class StationControllerTest extends MockBeanInjection {
 
     @Test
     void 충전소를_검색한다() throws Exception {
-        when(stationQueryService.searchStations(any(), any(), anyInt()))
+        when(stationQueryService.searchStations(any(), any(), anyInt(), anyInt()))
                 .thenReturn(new StationsSearchResponse(
                         2L,
                         List.of(
@@ -211,7 +211,7 @@ class StationControllerTest extends MockBeanInjection {
                         )
                 ));
 
-        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&scope=stationId&scope=stationName&scope=address&scope=latitude&scope=longitude&limit=12"))
+        mockMvc.perform(RestDocumentationRequestBuilders.get("/stations/search?q=선릉&scope=stationId&scope=stationName&scope=address&scope=latitude&scope=longitude&page=1&limit=12"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.totalCount").value(2))
                 .andExpect(jsonPath("$.stations", hasSize(2)))
@@ -219,6 +219,7 @@ class StationControllerTest extends MockBeanInjection {
                         requestParameters(
                                 parameterWithName("q").description("검색어"),
                                 parameterWithName("scope").description("검색 범위"),
+                                parameterWithName("page").description("페이지 번호"),
                                 parameterWithName("limit").description("검색 결과 개수")
                         ),
                         responseFields(

--- a/backend/src/test/java/com/carffeine/carffeine/station/service/station/StationQueryServiceTest.java
+++ b/backend/src/test/java/com/carffeine/carffeine/station/service/station/StationQueryServiceTest.java
@@ -297,7 +297,6 @@ public class StationQueryServiceTest extends IntegrationTest {
     void 총_15개의_충전소_중_관련_검색어에_맞는_충전소가_검색된다() {
         // given
         List<StationSearchResponse> stations = new ArrayList<>();
-        List<StationSearchResponse> expected = new ArrayList<>();
         for (int i = 0; i < 15; i++) {
             String stationId = "stationId" + String.format("%02d", i);
             String stationName = "stationName" + String.format("%02d", i);
@@ -330,11 +329,12 @@ public class StationQueryServiceTest extends IntegrationTest {
                     station.getLatitude().getValue(),
                     station.getLongitude().getValue()
             ));
-            expected = stations.stream().
-                    filter(it -> it.stationName().contains("stationName1"))
-                    .limit(5).toList();
             stationRepository.save(station);
         }
+
+        List<StationSearchResponse> expected = stations.stream().
+                filter(it -> it.stationName().contains("stationName1"))
+                .limit(5).toList();
 
         // when
         StationsSearchResponse result = stationQueryService.searchStations("stationName1", Set.of("stationId", "stationName", "address", "latitude", "longitude"), 1, 12);
@@ -348,7 +348,6 @@ public class StationQueryServiceTest extends IntegrationTest {
     void 총_15개의_충전소_중_관련_검색어에_맞는_충전소가_최대_12개_검색된다() {
         // given
         List<StationSearchResponse> stations = new ArrayList<>();
-        List<StationSearchResponse> expected = new ArrayList<>();
         for (int i = 0; i < 15; i++) {
             String stationId = "stationId" + String.format("%02d", i);
             Station station = Station.builder()
@@ -380,11 +379,12 @@ public class StationQueryServiceTest extends IntegrationTest {
                     station.getLatitude().getValue(),
                     station.getLongitude().getValue()
             ));
-            expected = stations.stream()
-                    .filter(it -> it.stationName().contains("충전소"))
-                    .limit(12).toList();
             stationRepository.save(station);
         }
+
+        List<StationSearchResponse> expected = stations.stream()
+                .filter(it -> it.stationName().contains("충전소"))
+                .limit(12).toList();
 
         // when
         StationsSearchResponse result = stationQueryService.searchStations("충전소", Set.of("stationId", "stationName", "address", "latitude", "longitude"), 1, 12);


### PR DESCRIPTION
## 📄 Summary
> refactor: 충전소 및 지역 검색 시 충전기가 아닌 충전소 기준으로 조회되도록 변경한다

## 🕰️ Actual Time of Completion
> 20분

## 🙋🏻 More
> 
아래는 메서드 호출 시 발생하는 쿼리입니다.
```
Hibernate: 
    select
        station0_.station_id as col_0_0_,
        station0_.station_name as col_1_0_,
        station0_.address as col_2_0_,
        station0_.latitude as col_3_0_,
        station0_.longitude as col_4_0_ 
    from
        charge_station station0_ 
    where
        station0_.station_name like ? escape '!' 
        or station0_.address like ? escape '!' 
    order by
        station0_.station_id asc limit ?
Hibernate: 
    select
        count(station0_.station_id) as col_0_0_ 
    from
        charge_station station0_ 
    where
        station0_.station_name like ? escape '!' 
        or station0_.address like ? escape '!'
```

close #697