### PR TITLE
refactor: 인포 윈도우에서 상세정보 확인이 가능함을 알린다

### DIFF
--- a/frontend/src/components/common/Box/Box.tsx
+++ b/frontend/src/components/common/Box/Box.tsx
@@ -10,11 +10,11 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement>, SpacingProps {
   children?: ReactNode;
   border?: boolean;
   height?: number | string;
-  minHeight?: string;
-  maxHeight?: string;
+  minHeight?: number | string;
+  maxHeight?: number | string;
   width?: number | string;
-  minWidth?: string;
-  maxWidth?: string;
+  minWidth?: number | string;
+  maxWidth?: number | string;
   bgColor?: string;
   color?: string;
   position?: 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
@@ -31,12 +31,12 @@ const BoxWrapper = styled.div<BoxProps>`
   ${({ border }) => border && `border: 0.1px solid #66666666; border-radius:0.4rem;`}
 
   height: ${({ height }) => (typeof height === 'string' ? height : `${height * 0.4}rem`)};
-  min-height: ${({ minHeight }) => minHeight};
-  max-height: ${({ maxHeight }) => maxHeight};
+  min-height: ${({ minHeight }) => (typeof minHeight === 'string' ? minHeight : `${minHeight}rem`)};
+  max-height: ${({ maxHeight }) => (typeof maxHeight === 'string' ? maxHeight : `${maxHeight}rem`)};
 
   width: ${({ width }) => (typeof width === 'string' ? width : `${width * 0.4}rem`)};
-  min-width: ${({ minWidth }) => minWidth};
-  max-width: ${({ maxWidth }) => maxWidth};
+  min-width: ${({ minWidth }) => (typeof minWidth === 'string' ? minWidth : `${minWidth}rem`)};
+  max-width: ${({ maxWidth }) => (typeof maxWidth === 'string' ? maxWidth : `${maxWidth}rem`)};
 
   ${({ bgColor }) => bgColor && `background: ${bgColor}`};
   ${({ color }) => color && `color: ${color}`};

--- a/frontend/src/components/common/Box/Box.tsx
+++ b/frontend/src/components/common/Box/Box.tsx
@@ -10,11 +10,11 @@ export interface BoxProps extends HTMLAttributes<HTMLDivElement>, SpacingProps {
   children?: ReactNode;
   border?: boolean;
   height?: number | string;
-  minHeight?: number | string;
-  maxHeight?: number | string;
+  minHeight?: string;
+  maxHeight?: string;
   width?: number | string;
-  minWidth?: number | string;
-  maxWidth?: number | string;
+  minWidth?: string;
+  maxWidth?: string;
   bgColor?: string;
   color?: string;
   position?: 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
@@ -31,17 +31,12 @@ const BoxWrapper = styled.div<BoxProps>`
   ${({ border }) => border && `border: 0.1px solid #66666666; border-radius:0.4rem;`}
 
   height: ${({ height }) => (typeof height === 'string' ? height : `${height * 0.4}rem`)};
-  width: ${({ width }) => (typeof width === 'string' ? width : `${width * 0.4}rem`)};
-  min-height: ${({ minHeight }) =>
-    typeof minHeight === 'string' ? minHeight : `${minHeight * 0.4}rem`};
-  max-height: ${({ maxHeight }) =>
-    typeof maxHeight === 'string' ? maxHeight : `${maxHeight * 0.4}rem`};
+  min-height: ${({ minHeight }) => minHeight};
+  max-height: ${({ maxHeight }) => maxHeight};
 
   width: ${({ width }) => (typeof width === 'string' ? width : `${width * 0.4}rem`)};
-  min-width: ${({ minWidth }) =>
-    typeof minWidth === 'string' ? minWidth : `${minWidth * 0.4}rem`};
-  max-width: ${({ maxWidth }) =>
-    typeof maxWidth === 'string' ? maxWidth : `${maxWidth * 0.4}rem`};
+  min-width: ${({ minWidth }) => minWidth};
+  max-width: ${({ maxWidth }) => maxWidth};
 
   ${({ bgColor }) => bgColor && `background: ${bgColor}`};
   ${({ color }) => color && `color: ${color}`};

--- a/frontend/src/components/common/Box/Box.tsx
+++ b/frontend/src/components/common/Box/Box.tsx
@@ -9,12 +9,12 @@ import { spacing } from '@common/systems';
 export interface BoxProps extends HTMLAttributes<HTMLDivElement>, SpacingProps {
   children?: ReactNode;
   border?: boolean;
-  height?: number;
-  minHeight?: number;
-  maxHeight?: number;
+  height?: number | string;
+  minHeight?: number | string;
+  maxHeight?: number | string;
   width?: number | string;
-  minWidth?: number;
-  maxWidth?: number;
+  minWidth?: number | string;
+  maxWidth?: number | string;
   bgColor?: string;
   color?: string;
   position?: 'static' | 'relative' | 'absolute' | 'fixed' | 'sticky';
@@ -30,13 +30,18 @@ const BoxWrapper = styled.div<BoxProps>`
 
   ${({ border }) => border && `border: 0.1px solid #66666666; border-radius:0.4rem;`}
 
-  ${({ height }) => height && `height: ${height * 0.4}rem`};
-  ${({ minHeight }) => minHeight && `min-height: ${minHeight * 0.4}rem`};
-  ${({ maxHeight }) => maxHeight && `max-height: ${maxHeight * 0.4}rem`};
+  height: ${({ height }) => (typeof height === 'string' ? height : `${height * 0.4}rem`)};
+  width: ${({ width }) => (typeof width === 'string' ? width : `${width * 0.4}rem`)};
+  min-height: ${({ minHeight }) =>
+    typeof minHeight === 'string' ? minHeight : `${minHeight * 0.4}rem`};
+  max-height: ${({ maxHeight }) =>
+    typeof maxHeight === 'string' ? maxHeight : `${maxHeight * 0.4}rem`};
 
   width: ${({ width }) => (typeof width === 'string' ? width : `${width * 0.4}rem`)};
-  ${({ minWidth }) => minWidth && `min-height: ${minWidth * 0.4}rem`};
-  ${({ maxWidth }) => maxWidth && `max-height: ${maxWidth * 0.4}rem`};
+  min-width: ${({ minWidth }) =>
+    typeof minWidth === 'string' ? minWidth : `${minWidth * 0.4}rem`};
+  max-width: ${({ maxWidth }) =>
+    typeof maxWidth === 'string' ? maxWidth : `${maxWidth * 0.4}rem`};
 
   ${({ bgColor }) => bgColor && `background: ${bgColor}`};
   ${({ color }) => color && `color: ${color}`};

--- a/frontend/src/components/common/FlexBox/FlexBox.tsx
+++ b/frontend/src/components/common/FlexBox/FlexBox.tsx
@@ -19,8 +19,12 @@ export const FLEX_BOX_ITEM_POSITION = {
 
 export interface FlexBoxProps extends HTMLAttributes<HTMLDivElement>, SpacingProps {
   tag?: string;
-  width?: string | number;
-  height?: string | number;
+  height?: number | string;
+  minHeight?: string;
+  maxHeight?: string;
+  width?: number | string;
+  minWidth?: string;
+  maxWidth?: string;
   justifyContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
   alignItems?: keyof typeof FLEX_BOX_ITEM_POSITION;
   alignContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
@@ -38,14 +42,27 @@ export interface FlexBoxProps extends HTMLAttributes<HTMLDivElement>, SpacingPro
 
 export type StyledFlexBoxType = Omit<
   FlexBoxProps,
-  'noRadius' | 'rowGap' | 'columnGap' | 'justifyContent' | 'alignItems' | 'alignContent'
+  | 'noRadius'
+  | 'rowGap'
+  | 'columnGap'
+  | 'justifyContent'
+  | 'alignItems'
+  | 'alignContent'
+  | 'minHeight'
+  | 'maxHeight'
+  | 'minWidth'
+  | 'maxWidth'
 > & {
-  $noRadius: BorderRadiusDirectionType;
-  $rowGap: number;
-  $columnGap: number;
-  $justifyContent: keyof typeof FLEX_BOX_ITEM_POSITION;
-  $alignItems: keyof typeof FLEX_BOX_ITEM_POSITION;
-  $alignContent: keyof typeof FLEX_BOX_ITEM_POSITION;
+  $noRadius?: BorderRadiusDirectionType;
+  $rowGap?: number;
+  $columnGap?: number;
+  $justifyContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
+  $alignItems?: keyof typeof FLEX_BOX_ITEM_POSITION;
+  $alignContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
+  $minHeight?: string;
+  $maxHeight?: string;
+  $minWidth?: string;
+  $maxWidth?: string;
 };
 
 // TODO: tag가 바뀌었을 때 ref의 타입을 바꾸는 로직을 추가한다.
@@ -58,6 +75,10 @@ const FlexBox = ({
   justifyContent,
   alignItems,
   alignContent,
+  minHeight,
+  maxHeight,
+  minWidth,
+  maxWidth,
   ...props
 }: FlexBoxProps) => {
   const changeableTag = tag || 'div';
@@ -71,6 +92,10 @@ const FlexBox = ({
       $justifyContent={justifyContent}
       $alignItems={alignItems}
       $alignContent={alignContent}
+      $minHeight={minHeight}
+      $maxHeight={maxHeight}
+      $minWidth={minWidth}
+      $maxWidth={maxWidth}
       {...props}
     >
       {children}
@@ -94,7 +119,13 @@ const S = {
     ${spacing};
 
     width: ${({ width }) => getSize(width)};
+    min-width: ${({ $minWidth }) => $minWidth};
+    max-width: ${({ $maxWidth }) => $maxWidth};
+
     height: ${({ height }) => getSize(height)};
+    min-height: ${({ $minHeight }) => $minHeight};
+    max-height: ${({ $maxHeight }) => $maxHeight};
+
     flex-wrap: ${({ nowrap }) => (nowrap ? 'nowrap' : 'wrap')};
     flex-direction: ${({ direction }) => (direction ? direction : 'row')};
     justify-content: ${({ $justifyContent }) => FLEX_BOX_ITEM_POSITION[$justifyContent]};

--- a/frontend/src/components/common/FlexBox/FlexBox.tsx
+++ b/frontend/src/components/common/FlexBox/FlexBox.tsx
@@ -65,7 +65,6 @@ export type StyledFlexBoxType = Omit<
   $maxWidth?: number | string;
 };
 
-// TODO: tag가 바뀌었을 때 ref의 타입을 바꾸는 로직을 추가한다.
 const FlexBox = ({
   children,
   tag,

--- a/frontend/src/components/common/FlexBox/FlexBox.tsx
+++ b/frontend/src/components/common/FlexBox/FlexBox.tsx
@@ -20,11 +20,11 @@ export const FLEX_BOX_ITEM_POSITION = {
 export interface FlexBoxProps extends HTMLAttributes<HTMLDivElement>, SpacingProps {
   tag?: string;
   height?: number | string;
-  minHeight?: string;
-  maxHeight?: string;
+  minHeight?: number | string;
+  maxHeight?: number | string;
   width?: number | string;
-  minWidth?: string;
-  maxWidth?: string;
+  minWidth?: number | string;
+  maxWidth?: number | string;
   justifyContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
   alignItems?: keyof typeof FLEX_BOX_ITEM_POSITION;
   alignContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
@@ -59,10 +59,10 @@ export type StyledFlexBoxType = Omit<
   $justifyContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
   $alignItems?: keyof typeof FLEX_BOX_ITEM_POSITION;
   $alignContent?: keyof typeof FLEX_BOX_ITEM_POSITION;
-  $minHeight?: string;
-  $maxHeight?: string;
-  $minWidth?: string;
-  $maxWidth?: string;
+  $minHeight?: number | string;
+  $maxHeight?: number | string;
+  $minWidth?: number | string;
+  $maxWidth?: number | string;
 };
 
 // TODO: tag가 바뀌었을 때 ref의 타입을 바꾸는 로직을 추가한다.
@@ -119,12 +119,16 @@ const S = {
     ${spacing};
 
     width: ${({ width }) => getSize(width)};
-    min-width: ${({ $minWidth }) => $minWidth};
-    max-width: ${({ $maxWidth }) => $maxWidth};
+    min-width: ${({ $minWidth }) =>
+      typeof $minWidth === 'string' ? $minWidth : `${$minWidth}rem`};
+    max-width: ${({ $maxWidth }) =>
+      typeof $maxWidth === 'string' ? $maxWidth : `${$maxWidth}rem`};
 
     height: ${({ height }) => getSize(height)};
-    min-height: ${({ $minHeight }) => $minHeight};
-    max-height: ${({ $maxHeight }) => $maxHeight};
+    min-height: ${({ $minHeight }) =>
+      typeof $minHeight === 'string' ? $minHeight : `${$minHeight}rem`};
+    max-height: ${({ $maxHeight }) =>
+      typeof $maxHeight === 'string' ? $maxHeight : `${$maxHeight}rem`};
 
     flex-wrap: ${({ nowrap }) => (nowrap ? 'nowrap' : 'wrap')};
     flex-direction: ${({ direction }) => (direction ? direction : 'row')};

--- a/frontend/src/components/ui/Error.tsx
+++ b/frontend/src/components/ui/Error.tsx
@@ -1,0 +1,40 @@
+import Box from '@common/Box';
+import ButtonNext from '@common/ButtonNext';
+import FlexBox from '@common/FlexBox';
+import Text from '@common/Text';
+
+export interface ErrorProps {
+  title: string;
+  message: string;
+  subMessage?: string;
+  handleRetry?: () => void;
+  minHeight?: string;
+}
+
+const Error = ({ title, message, subMessage, handleRetry, minHeight }: ErrorProps) => {
+  return (
+    <FlexBox
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignItems="center"
+      minHeight={minHeight}
+    >
+      <Box>
+        <Text align="center" css={{ fontSize: '10rem', fontWeight: 'bold' }} mb={7}>
+          {title}
+        </Text>
+        <Text align="center" mb={2}>
+          {message}
+        </Text>
+        <Text align="center">{subMessage}</Text>
+        <FlexBox justifyContent="center">
+          <ButtonNext onClick={handleRetry} variant="outlined" color="dark" size="xs" my={2}>
+            다시 시도하기
+          </ButtonNext>
+        </FlexBox>
+      </Box>
+    </FlexBox>
+  );
+};
+export default Error;

--- a/frontend/src/components/ui/Error.tsx
+++ b/frontend/src/components/ui/Error.tsx
@@ -8,7 +8,7 @@ export interface ErrorProps {
   message: string;
   subMessage?: string;
   handleRetry?: () => void;
-  minHeight?: string;
+  minHeight?: string | number;
 }
 
 const Error = ({ title, message, subMessage, handleRetry, minHeight }: ErrorProps) => {

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
@@ -5,6 +5,7 @@ import { useStationCongestionStatistics } from '@hooks/tanstack-query/station-de
 import ButtonNext from '@common/ButtonNext';
 import FlexBox from '@common/FlexBox';
 
+import Error from '@ui/Error';
 import ShowHideButton from '@ui/ShowHideButton';
 import StatisticsGraph from '@ui/StatisticsGraph';
 
@@ -35,10 +36,13 @@ const Statistics = ({ stationId, setIsStatisticsOpen, dayOfWeek, onChangeDayOfWe
 
   if (isError) {
     return (
-      <>
-        <p>에러 발생</p>
-        <button onClick={handleRetry}>Retry</button>
-      </>
+      <Error
+        title="앗"
+        message="데이터를 불러오는데 실패했어요."
+        subMessage="잠시 후 다시 시도해주세요."
+        handleRetry={handleRetry}
+        minHeight={`${493 + 22}px`}
+      />
     );
   }
 

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
@@ -41,7 +41,7 @@ const Statistics = ({ stationId, setIsStatisticsOpen, dayOfWeek, onChangeDayOfWe
         message="데이터를 불러오는데 실패했어요."
         subMessage="잠시 후 다시 시도해주세요."
         handleRetry={handleRetry}
-        minHeight={`${493 + 22}px`}
+        minHeight={`${49.3 + 2.2}rem`}
       />
     );
   }

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
@@ -41,7 +41,7 @@ const Statistics = ({ stationId, setIsStatisticsOpen, dayOfWeek, onChangeDayOfWe
         message="데이터를 불러오는데 실패했어요."
         subMessage="잠시 후 다시 시도해주세요."
         handleRetry={handleRetry}
-        minHeight={`${49.3 + 2.2}rem`}
+        minHeight={49.3 + 2.2}
       />
     );
   }

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
@@ -21,11 +21,26 @@ interface Props {
 }
 
 const Statistics = ({ stationId, setIsStatisticsOpen, dayOfWeek, onChangeDayOfWeek }: Props) => {
-  const { data: congestionStatistics, isLoading } = useStationCongestionStatistics(
-    stationId,
-    dayOfWeek
-  );
+  const {
+    data: congestionStatistics,
+    isLoading,
+    isError,
+    refetch,
+  } = useStationCongestionStatistics(stationId, dayOfWeek);
   const [chargingSpeed, setChargingSpeed] = useState<keyof typeof CHARGING_SPEED>('standard');
+
+  const handleRetry = () => {
+    refetch();
+  };
+
+  if (isError) {
+    return (
+      <>
+        <p>에러 발생</p>
+        <button onClick={handleRetry}>Retry</button>
+      </>
+    );
+  }
 
   return (
     <>

--- a/frontend/src/components/ui/StationSummaryWindow.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow.tsx
@@ -30,7 +30,6 @@ const StationSummaryWindow = ({ stationId }: Props) => {
   const { openLastPanel } = useNavigationBar();
 
   const { isLoading, stationSummary } = useFetchStationSummary(stationId);
-  const { stationName, companyName, address, operatingTime, quickChargerCount } = stationSummary;
 
   const handleOpenStationDetail = () => {
     setSelectedStationId(stationId);
@@ -50,57 +49,57 @@ const StationSummaryWindow = ({ stationId }: Props) => {
     );
   }
 
+  const { stationName, companyName, address, operatingTime, quickChargerCount } = stationSummary;
+
   return (
-    <>
-      <ListItem tag="div" key={stationId} css={padding}>
-        <Button width="100%" shadow css={foundStationButton} onClick={handleOpenStationDetail}>
-          <FlexBox alignItems="start" justifyContent="between" nowrap columnGap={2.8}>
-            <article>
-              <Text
-                tag="h3"
-                align="left"
-                variant="subtitle"
-                title={stationName}
-                lineClamp={1}
-                css={companyNameText}
-              >
-                {companyName}
-              </Text>
-              <Text tag="h3" align="left" variant="h5" title={stationName} lineClamp={1}>
-                {stationName}
-              </Text>
-              <Text variant="body" align="left" lineClamp={1} mb={1} color="#585858">
-                {address === 'null' || !address ? '주소 미확인' : address}
-              </Text>
-              <Text variant="caption" align="left" lineClamp={1} mb={1.8} color="#585858">
-                {operatingTime}
-              </Text>
-            </article>
-            {quickChargerCount !== 0 && <ChargingSpeedIcon />}
-          </FlexBox>
-        </Button>
-        <FlexBox direction="row" justifyContent="between" mb={1.8}>
-          <ButtonNext
-            variant="outlined"
-            size="xs"
-            color="secondary"
-            css={{ width: '28%' }}
-            onClick={handleCloseStationSummary}
-          >
-            닫기
-          </ButtonNext>
-          <ButtonNext
-            variant="contained"
-            size="xs"
-            color="dark"
-            css={{ width: '68%' }}
-            onClick={handleOpenStationDetail}
-          >
-            상세보기
-          </ButtonNext>
+    <ListItem tag="div" key={stationId} css={padding}>
+      <Button width="100%" shadow css={foundStationButton} onClick={handleOpenStationDetail}>
+        <FlexBox alignItems="start" justifyContent="between" nowrap columnGap={2.8}>
+          <article>
+            <Text
+              tag="h3"
+              align="left"
+              variant="subtitle"
+              title={stationName}
+              lineClamp={1}
+              css={companyNameText}
+            >
+              {companyName}
+            </Text>
+            <Text tag="h3" align="left" variant="h5" title={stationName} lineClamp={1}>
+              {stationName}
+            </Text>
+            <Text variant="body" align="left" lineClamp={1} mb={1} color="#585858">
+              {address === 'null' || !address ? '주소 미확인' : address}
+            </Text>
+            <Text variant="caption" align="left" lineClamp={1} mb={1.8} color="#585858">
+              {operatingTime}
+            </Text>
+          </article>
+          {quickChargerCount !== 0 && <ChargingSpeedIcon />}
         </FlexBox>
-      </ListItem>
-    </>
+      </Button>
+      <FlexBox direction="row" justifyContent="between" mb={1.8}>
+        <ButtonNext
+          variant="outlined"
+          size="xs"
+          color="secondary"
+          css={{ width: '28%' }}
+          onClick={handleCloseStationSummary}
+        >
+          닫기
+        </ButtonNext>
+        <ButtonNext
+          variant="contained"
+          size="xs"
+          color="dark"
+          css={{ width: '68%' }}
+          onClick={handleOpenStationDetail}
+        >
+          상세보기
+        </ButtonNext>
+      </FlexBox>
+    </ListItem>
   );
 };
 

--- a/frontend/src/components/ui/StationSummaryWindow.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow.tsx
@@ -1,4 +1,3 @@
-import { XMarkIcon } from '@heroicons/react/24/outline';
 import { css } from 'styled-components';
 
 import type { MouseEvent } from 'react';
@@ -11,6 +10,7 @@ import { selectedStationIdStore } from '@stores/selectedStationStore';
 import { useFetchStationSummary } from '@hooks/fetch/useFetchStationSummary';
 
 import Button from '@common/Button';
+import ButtonNext from '@common/ButtonNext';
 import FlexBox from '@common/FlexBox';
 import List from '@common/List';
 import ListItem from '@common/ListItem';
@@ -61,45 +61,68 @@ const StationSummaryWindow = ({ stationId }: Props) => {
   };
 
   return (
-    <ListItem tag="div" key={stationId} css={padding}>
-      <Button width="100%" shadow css={foundStationButton} onClick={handleOpenStationDetail}>
-        <Button onClick={handleCloseStationSummary} css={closeButtonCss}>
-          <XMarkIcon fill="#333" width={24} />
+    <>
+      <ListItem tag="div" key={stationId} css={padding}>
+        <Button width="100%" shadow css={foundStationButton} onClick={handleOpenStationDetail}>
+          {/*<Button onClick={handleCloseStationSummary} css={closeButtonCss}>*/}
+          {/*  <XMarkIcon fill="#333" width={24} />*/}
+          {/*</Button>*/}
+          <FlexBox alignItems="start" justifyContent="between" nowrap columnGap={2.8}>
+            <article>
+              <Text
+                tag="h3"
+                align="left"
+                variant="subtitle"
+                title={stationName}
+                lineClamp={1}
+                css={companyNameText}
+              >
+                {companyName}
+              </Text>
+              <Text tag="h3" align="left" variant="h5" title={stationName} lineClamp={1}>
+                {stationName}
+              </Text>
+              <Text variant="body" align="left" lineClamp={1} mb={1} color="#585858">
+                {address === 'null' || !address ? '주소 미확인' : address}
+              </Text>
+              <Text variant="caption" align="left" lineClamp={1} mb={1.8} color="#585858">
+                {operatingTime}
+              </Text>
+              {/*<FlexBox columnGap={3}>*/}
+              {/*  <Text variant="label" align="left" color="#4b4b4b" css={labelStyle}>*/}
+              {/*    {isPrivate ? '이용 제한' : '외부인 개방'}*/}
+              {/*  </Text>*/}
+              {/*  <Text variant="label" align="left" color="#4b4b4b" css={labelStyle}>*/}
+              {/*    {isParkingFree ? '무료 주차' : '유료 주차'}*/}
+              {/*  </Text>*/}
+              {/*</FlexBox>*/}
+            </article>
+            {quickChargerCount !== 0 && <ChargingSpeedIcon />}
+          </FlexBox>
         </Button>
-        <FlexBox alignItems="start" mr={2} justifyContent="between" nowrap columnGap={2.8}>
-          <article>
-            <Text
-              tag="h3"
-              align="left"
-              variant="subtitle"
-              title={stationName}
-              lineClamp={1}
-              css={companyNameText}
-            >
-              {companyName}
-            </Text>
-            <Text tag="h3" align="left" variant="h5" title={stationName} lineClamp={1}>
-              {stationName}
-            </Text>
-            <Text variant="body" align="left" lineClamp={1} mb={1} color="#585858">
-              {address === 'null' || !address ? '주소 미확인' : address}
-            </Text>
-            <Text variant="caption" align="left" lineClamp={1} mb={3.5} color="#585858">
-              {operatingTime}
-            </Text>
-            <FlexBox columnGap={3}>
-              <Text variant="label" align="left" color="#4b4b4b" css={labelStyle}>
-                {isPrivate ? '이용 제한' : '외부인 개방'}
-              </Text>
-              <Text variant="label" align="left" color="#4b4b4b" css={labelStyle}>
-                {isParkingFree ? '무료 주차' : '유료 주차'}
-              </Text>
-            </FlexBox>
-          </article>
-          {quickChargerCount !== 0 && <ChargingSpeedIcon />}
+        <FlexBox direction="row" justifyContent="between" mb={1.8}>
+          <ButtonNext
+            variant="outlined"
+            size="xs"
+            color="secondary"
+            css={{ width: '28%' }}
+            onClick={handleCloseStationSummary}
+          >
+            닫기
+          </ButtonNext>
+          <ButtonNext
+            variant="contained"
+            size="xs"
+            // fullWidth
+            color="dark"
+            css={{ width: '68%' }}
+            onClick={handleOpenStationDetail}
+          >
+            상세보기
+          </ButtonNext>
         </FlexBox>
-      </Button>
-    </ListItem>
+      </ListItem>
+    </>
   );
 };
 
@@ -112,7 +135,7 @@ const companyNameText = css`
 `;
 
 const foundStationButton = css`
-  padding: 1.6rem 1.2rem;
+  padding: 1.2rem 1.2rem 1.6rem;
   box-shadow: none;
 `;
 
@@ -129,3 +152,5 @@ const closeButtonCss = css`
 `;
 
 export default StationSummaryWindow;
+
+//0.4rem 1.2rem 1.6rem 1.2rem

--- a/frontend/src/components/ui/StationSummaryWindow.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow.tsx
@@ -12,13 +12,12 @@ import { useFetchStationSummary } from '@hooks/fetch/useFetchStationSummary';
 import Button from '@common/Button';
 import ButtonNext from '@common/ButtonNext';
 import FlexBox from '@common/FlexBox';
-import List from '@common/List';
 import ListItem from '@common/ListItem';
+import Loader from '@common/Loader';
 import Text from '@common/Text';
 
 import ChargingSpeedIcon from './ChargingSpeedIcon';
 import StationDetailsWindow from './StationDetailsWindow';
-import StationSummaryCardSkeleton from './StationList/StationSummaryCardSkeleton';
 import { useNavigationBar } from './compound/NavigationBar/hooks/useNavigationBar';
 
 interface Props {
@@ -31,24 +30,7 @@ const StationSummaryWindow = ({ stationId }: Props) => {
   const { openLastPanel } = useNavigationBar();
 
   const { isLoading, stationSummary } = useFetchStationSummary(stationId);
-
-  if (isLoading || stationSummary === null) {
-    return (
-      <List>
-        <StationSummaryCardSkeleton />
-      </List>
-    );
-  }
-
-  const {
-    stationName,
-    companyName,
-    address,
-    operatingTime,
-    isPrivate,
-    isParkingFree,
-    quickChargerCount,
-  } = stationSummary;
+  const { stationName, companyName, address, operatingTime, quickChargerCount } = stationSummary;
 
   const handleOpenStationDetail = () => {
     setSelectedStationId(stationId);
@@ -60,13 +42,18 @@ const StationSummaryWindow = ({ stationId }: Props) => {
     infoWindowInstance.infoWindowInstance.close();
   };
 
+  if (isLoading || stationSummary === null) {
+    return (
+      <FlexBox justifyContent="center" alignItems="center" height="184.39px">
+        <Loader size="xxl" />
+      </FlexBox>
+    );
+  }
+
   return (
     <>
       <ListItem tag="div" key={stationId} css={padding}>
         <Button width="100%" shadow css={foundStationButton} onClick={handleOpenStationDetail}>
-          {/*<Button onClick={handleCloseStationSummary} css={closeButtonCss}>*/}
-          {/*  <XMarkIcon fill="#333" width={24} />*/}
-          {/*</Button>*/}
           <FlexBox alignItems="start" justifyContent="between" nowrap columnGap={2.8}>
             <article>
               <Text
@@ -88,14 +75,6 @@ const StationSummaryWindow = ({ stationId }: Props) => {
               <Text variant="caption" align="left" lineClamp={1} mb={1.8} color="#585858">
                 {operatingTime}
               </Text>
-              {/*<FlexBox columnGap={3}>*/}
-              {/*  <Text variant="label" align="left" color="#4b4b4b" css={labelStyle}>*/}
-              {/*    {isPrivate ? '이용 제한' : '외부인 개방'}*/}
-              {/*  </Text>*/}
-              {/*  <Text variant="label" align="left" color="#4b4b4b" css={labelStyle}>*/}
-              {/*    {isParkingFree ? '무료 주차' : '유료 주차'}*/}
-              {/*  </Text>*/}
-              {/*</FlexBox>*/}
             </article>
             {quickChargerCount !== 0 && <ChargingSpeedIcon />}
           </FlexBox>
@@ -113,7 +92,6 @@ const StationSummaryWindow = ({ stationId }: Props) => {
           <ButtonNext
             variant="contained"
             size="xs"
-            // fullWidth
             color="dark"
             css={{ width: '68%' }}
             onClick={handleOpenStationDetail}
@@ -135,22 +113,8 @@ const companyNameText = css`
 `;
 
 const foundStationButton = css`
-  padding: 1.2rem 1.2rem 1.6rem;
+  padding: 1.2rem 1.2rem 1.4rem;
   box-shadow: none;
 `;
 
-const labelStyle = css`
-  padding: 0.2rem 1rem 0.3rem;
-  background: var(--light-color);
-  border-radius: 8px;
-`;
-
-const closeButtonCss = css`
-  position: absolute;
-  top: 0.8rem;
-  right: 0.8rem;
-`;
-
 export default StationSummaryWindow;
-
-//0.4rem 1.2rem 1.6rem 1.2rem


### PR DESCRIPTION
## 📄 Summary
> 인포 윈도우에서 상세정보 확인이 가능함을 알립니다.

- 로딩이 스피너로 바뀌었습니다.
- 상세정보를 확인하는 버튼이 추가로 생겼습니다.
- 기존 x 버튼이 사라지고 닫기 버튼이 따로 생겼습니다.

[before]

<img width="399" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/69189073/2e8c9bde-c375-4acc-91ac-127e4f8c150a">


[after]


<img width="387" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/69189073/355a31b3-a34b-4ba9-b30b-de978a62e791">


## 🕰️ Actual Time of Completion
> 2시간

## 🙋🏻 More
> 


close #736