### PR TITLE
refactor: 혼잡도 그래프 ratio 서버 변경에 맞춰 값 변경한다

### DIFF
--- a/frontend/src/components/ui/StationDetailsWindow/congestion/Help.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/Help.tsx
@@ -49,31 +49,31 @@ const Help = () => {
           </TableRow>
           <TableRow>
             <td>
-              <Bar ratio={20} hour="02" align="column" />
+              <Bar ratio={0.2} hour="02" align="column" />
             </td>
             <TableData>20%</TableData>
           </TableRow>
           <TableRow>
             <td>
-              <Bar ratio={40} hour="03" align="column" />
+              <Bar ratio={0.4} hour="03" align="column" />
             </td>
             <TableData>40%</TableData>
           </TableRow>
           <TableRow>
             <td>
-              <Bar ratio={60} hour="04" align="column" />
+              <Bar ratio={0.6} hour="04" align="column" />
             </td>
             <TableData>60%</TableData>
           </TableRow>
           <TableRow>
             <td>
-              <Bar ratio={80} hour="05" align="column" />
+              <Bar ratio={0.8} hour="05" align="column" />
             </td>
             <TableData>80%</TableData>
           </TableRow>
           <TableRow>
             <td>
-              <Bar ratio={100} hour="06" align="column" />
+              <Bar ratio={1} hour="06" align="column" />
             </td>
             <TableData>100%</TableData>
           </TableRow>


### PR DESCRIPTION
[#744]

## 📄 Summary
> 혼잡도 통계 설명 모달 그래프를 수정한다.
>서버에서 주는 ratio 변경에 맞춰 수정한다.
> ex) 20 → 0.2

<img width="282" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/3c089e29-7f1a-4e86-857e-257caa547ba5">


## 🕰️ Actual Time of Completion
> 3분

## 🙋🏻 More
> 


close #744