### PR TITLE
design: 충전소 간단 정보창 상세보기 버튼 모바일에서만 보이도록 개선한다

### DIFF
--- a/frontend/src/components/common/ButtonNext/ButtonNext.tsx
+++ b/frontend/src/components/common/ButtonNext/ButtonNext.tsx
@@ -34,8 +34,6 @@ const ButtonNext = ({ children, noTheme, ...props }: ButtonNextProps) => {
 
 const S = {
   Button: styled.button<ButtonNextProps>`
-    margin: 1px;
-
     border-radius: 6px;
     ${({ pill }) => pill && 'border-radius: 20px;'}
 
@@ -45,7 +43,7 @@ const S = {
       switch (variant) {
         case 'text':
           return css`
-            color: ${disabled ? '#a0a0a0' : color === 'light' ? '#000000' : getColor(color)};
+            color: ${disabled ? '#a0a0a0' : color === 'light' ? '#000' : getColor(color)};
             background: transparent;
             border: none;
 
@@ -55,19 +53,19 @@ const S = {
           `;
         case 'outlined':
           return css`
-            color: ${disabled ? '#a0a0a0' : color === 'light' ? '#000' : getColor(color)};
+            color: ${disabled ? '#a0a0a0' : color === 'light' ? '#333' : getColor(color)};
             background: transparent;
             border: 1.5px solid ${disabled ? '#a0a0a0' : getColor(color)};
 
             &:hover {
-              color: ${disabled ? '#a0a0a0' : '#fff'};
+              color: ${disabled ? '#a0a0a0' : color === 'light' ? '#333' : '#fff'};
               background: ${disabled ? 'transparent' : getHoverColor(color)};
             }
           `;
         case 'contained':
         default:
           return css`
-            color: ${disabled ? '#a0a0a0' : color === 'light' ? '#000000' : '#ffffff'};
+            color: ${disabled ? '#a0a0a0' : color === 'light' ? '#000' : '#ffffff'};
             background: ${disabled ? '#e0e0e0' : getColor(color)};
             border: 1.5px solid ${disabled ? '#e0e0e0' : getColor(color)};
 

--- a/frontend/src/components/ui/StationSummaryWindow/StationSummaryWindow.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow/StationSummaryWindow.tsx
@@ -10,21 +10,21 @@ import { selectedStationIdStore } from '@stores/selectedStationStore';
 import { useFetchStationSummary } from '@hooks/fetch/useFetchStationSummary';
 
 import Button from '@common/Button';
-import ButtonNext from '@common/ButtonNext';
 import FlexBox from '@common/FlexBox';
 import ListItem from '@common/ListItem';
 import Loader from '@common/Loader';
 import Text from '@common/Text';
 
-import ChargingSpeedIcon from './ChargingSpeedIcon';
-import StationDetailsWindow from './StationDetailsWindow';
-import { useNavigationBar } from './compound/NavigationBar/hooks/useNavigationBar';
+import ChargingSpeedIcon from '../ChargingSpeedIcon';
+import StationDetailsWindow from '../StationDetailsWindow';
+import { useNavigationBar } from '../compound/NavigationBar/hooks/useNavigationBar';
+import SummaryButtons from './SummaryButtons';
 
-interface Props {
+export interface StationSummaryProps {
   stationId: string;
 }
 
-const StationSummaryWindow = ({ stationId }: Props) => {
+const StationSummaryWindow = ({ stationId }: StationSummaryProps) => {
   const infoWindowInstance = useExternalValue(getStationSummaryWindowStore());
   const setSelectedStationId = useSetExternalState(selectedStationIdStore);
   const { openLastPanel } = useNavigationBar();
@@ -79,32 +79,16 @@ const StationSummaryWindow = ({ stationId }: Props) => {
           {quickChargerCount !== 0 && <ChargingSpeedIcon />}
         </FlexBox>
       </Button>
-      <FlexBox direction="row" justifyContent="between" mb={1.8}>
-        <ButtonNext
-          variant="outlined"
-          size="xs"
-          color="secondary"
-          css={{ width: '28%' }}
-          onClick={handleCloseStationSummary}
-        >
-          닫기
-        </ButtonNext>
-        <ButtonNext
-          variant="contained"
-          size="xs"
-          color="dark"
-          css={{ width: '68%' }}
-          onClick={handleOpenStationDetail}
-        >
-          상세보기
-        </ButtonNext>
-      </FlexBox>
+      <SummaryButtons
+        handleCloseStationSummary={handleCloseStationSummary}
+        handleOpenStationDetail={handleOpenStationDetail}
+      />
     </ListItem>
   );
 };
 
 const padding = css`
-  padding: 1.2rem;
+  padding: 2.4rem 2.4rem 1.8rem;
 `;
 
 const companyNameText = css`
@@ -112,7 +96,6 @@ const companyNameText = css`
 `;
 
 const foundStationButton = css`
-  padding: 1.2rem 1.2rem 1.4rem;
   box-shadow: none;
 `;
 

--- a/frontend/src/components/ui/StationSummaryWindow/SummaryButtons.stories.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow/SummaryButtons.stories.tsx
@@ -6,7 +6,6 @@ import SummaryButtons from './SummaryButtons';
 
 const meta = {
   title: 'UI/StationSummaryWindow/Buttons',
-  tags: ['autodocs'],
   component: SummaryButtons,
   args: {
     handleCloseStationSummary: () => {

--- a/frontend/src/components/ui/StationSummaryWindow/SummaryButtons.stories.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow/SummaryButtons.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta } from '@storybook/react';
+import styled from 'styled-components';
+
+import type { SummaryButtonsProps } from './SummaryButtons';
+import SummaryButtons from './SummaryButtons';
+
+const meta = {
+  title: 'UI/StationSummaryWindow/Buttons',
+  tags: ['autodocs'],
+  component: SummaryButtons,
+  args: {
+    handleCloseStationSummary: () => {
+      alert('충전소 간단 정보창이 닫혔습니다.');
+    },
+    handleOpenStationDetail: () => {
+      alert('충전소 상세 정보창이 열렸습니다.');
+    },
+  },
+  argTypes: {
+    handleCloseStationSummary: {
+      description: '충전소 간단 정보창을 닫을 수 있습니다.',
+    },
+    handleOpenStationDetail: {
+      description: '충전소 상세 정보창을 열 수 있습니다. 모바일에서만 보이는 버튼입니다.',
+    },
+  },
+} satisfies Meta<typeof SummaryButtons>;
+
+export default meta;
+
+export const Default = (args: SummaryButtonsProps) => {
+  return (
+    <Container>
+      <SummaryButtons {...args} />
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  width: 32rem;
+`;

--- a/frontend/src/components/ui/StationSummaryWindow/SummaryButtons.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow/SummaryButtons.tsx
@@ -1,0 +1,66 @@
+import { css } from 'styled-components';
+
+import type { MouseEvent } from 'react';
+
+import useMediaQueries from '@hooks/useMediaQueries';
+
+import ButtonNext from '@common/ButtonNext';
+import FlexBox from '@common/FlexBox';
+
+import { MOBILE_BREAKPOINT } from '@constants';
+
+export interface SummaryButtonsProps {
+  handleCloseStationSummary: (event: MouseEvent<HTMLButtonElement>) => void;
+  handleOpenStationDetail: () => void;
+}
+
+const SummaryButtons = ({
+  handleCloseStationSummary,
+  handleOpenStationDetail,
+}: SummaryButtonsProps) => {
+  const screen = useMediaQueries();
+
+  return (
+    <FlexBox
+      nowrap
+      direction="row"
+      justifyContent="between"
+      mt={2.5}
+      mb={screen.get('isMobile') ? 1 : 0}
+    >
+      <ButtonNext
+        variant="outlined"
+        size="xs"
+        color="secondary"
+        css={closeButtonCss}
+        onClick={handleCloseStationSummary}
+      >
+        닫기
+      </ButtonNext>
+      {screen.get('isMobile') && (
+        <ButtonNext
+          variant="contained"
+          size="xs"
+          color="dark"
+          css={{ width: '68%' }}
+          onClick={handleOpenStationDetail}
+        >
+          상세보기
+        </ButtonNext>
+      )}
+    </FlexBox>
+  );
+};
+
+const closeButtonCss = css`
+  width: 20%;
+  margin-left: auto;
+  border-color: #4d5053bf;
+
+  @media screen and (max-width: ${MOBILE_BREAKPOINT}px) {
+    width: 28%;
+    margin-left: 0;
+  }
+`;
+
+export default SummaryButtons;

--- a/frontend/src/components/ui/StationSummaryWindow/index.tsx
+++ b/frontend/src/components/ui/StationSummaryWindow/index.tsx
@@ -1,0 +1,3 @@
+import StationSummaryWindow from './StationSummaryWindow';
+
+export default StationSummaryWindow;

--- a/frontend/src/style/index.ts
+++ b/frontend/src/style/index.ts
@@ -66,7 +66,7 @@ export const getHoverColor = (color?: Color) => {
     case 'info':
       return '#0da8d6';
     case 'light':
-      return '#e2e6ea';
+      return '#f8f9fa';
     case 'disable':
       return '#9a9a9a';
     case 'dark':


### PR DESCRIPTION
[#747]

## 📄 Summary
> 충전소 간단 정보창 상세보기 버튼 모바일에서만 보이도록 개선
<img width="236" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/adf0a55c-3fd7-48a8-8388-c4587326aa13">

<img width="235" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/41bc6d79-d36c-45f2-9959-137c6c57d5f5">


( 임시 디자인입니다 )

## 🕰️ Actual Time of Completion
> 2시간

## 🙋🏻 More
> 


close #747