### PR TITLE
fix: 모바일 환경에서 충전소 리스트 더보기 버튼이 보이지 않는 문제를 해결한다.

### DIFF
--- a/frontend/src/components/ui/StationList/StationList.tsx
+++ b/frontend/src/components/ui/StationList/StationList.tsx
@@ -1,8 +1,9 @@
 import { css } from 'styled-components';
 
+import { useEffect, useRef } from 'react';
+
 import { useStationMarkers } from '@hooks/tanstack-query/station-markers/useStationMarkers';
 
-import ButtonNext from '@common/ButtonNext';
 import List from '@common/List';
 
 import EmptyStationsNotice from '@ui/StationList/EmptyStationsNotice';
@@ -26,6 +27,29 @@ const StationList = () => {
     loadMore,
     hasNextPage,
   } = useFetchStationSummaries(filteredMarkers ?? []);
+
+  const loadMoreElementRef = useRef(null);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting && hasNextPage) {
+          console.log('loadMore');
+          loadMore();
+        }
+      });
+    });
+
+    if (loadMoreElementRef.current) {
+      observer.observe(loadMoreElementRef.current);
+    }
+
+    return () => {
+      if (loadMoreElementRef.current) {
+        observer.unobserve(loadMoreElementRef.current);
+      }
+    };
+  }, [loadMore, hasNextPage]);
 
   const cachedStationSummaries = cachedStationSummariesActions.get();
 
@@ -61,11 +85,7 @@ const StationList = () => {
             ))}
           </>
         )}
-        {hasNextPage && (
-          <ButtonNext onClick={loadMore} fullWidth>
-            더 보 기
-          </ButtonNext>
-        )}
+        {hasNextPage && <div ref={loadMoreElementRef} />}
       </List>
     )
   );

--- a/frontend/src/components/ui/StationList/StationList.tsx
+++ b/frontend/src/components/ui/StationList/StationList.tsx
@@ -39,7 +39,6 @@ const StationList = () => {
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting && hasNextPage) {
-          console.log('loadMore');
           debouncedLoadMore();
         }
       });

--- a/frontend/src/components/ui/StationList/StationList.tsx
+++ b/frontend/src/components/ui/StationList/StationList.tsx
@@ -2,9 +2,13 @@ import { css } from 'styled-components';
 
 import { useEffect, useRef } from 'react';
 
+import { debounce } from '@utils/debounce';
+
 import { useStationMarkers } from '@hooks/tanstack-query/station-markers/useStationMarkers';
 
+import FlexBox from '@common/FlexBox';
 import List from '@common/List';
+import Text from '@common/Text';
 
 import EmptyStationsNotice from '@ui/StationList/EmptyStationsNotice';
 import StationSummaryCardSkeleton from '@ui/StationList/StationSummaryCardSkeleton';
@@ -29,13 +33,14 @@ const StationList = () => {
   } = useFetchStationSummaries(filteredMarkers ?? []);
 
   const loadMoreElementRef = useRef(null);
+  const debouncedLoadMore = debounce(loadMore, 500);
 
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting && hasNextPage) {
           console.log('loadMore');
-          loadMore();
+          debouncedLoadMore();
         }
       });
     });
@@ -85,7 +90,13 @@ const StationList = () => {
             ))}
           </>
         )}
-        {hasNextPage && <div ref={loadMoreElementRef} />}
+        {hasNextPage ? (
+          <div ref={loadMoreElementRef} />
+        ) : (
+          <FlexBox justifyContent="center" alignItems="center" my={3}>
+            <Text>주변의 모든 충전소를 불러왔습니다.</Text>
+          </FlexBox>
+        )}
       </List>
     )
   );

--- a/frontend/src/components/ui/StationList/StationList.tsx
+++ b/frontend/src/components/ui/StationList/StationList.tsx
@@ -33,13 +33,13 @@ const StationList = () => {
   } = useFetchStationSummaries(filteredMarkers ?? []);
 
   const loadMoreElementRef = useRef(null);
-  const debouncedLoadMore = debounce(loadMore, 500);
+  const loadMoreAfterDebounce = debounce(loadMore, 500);
 
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
       entries.forEach((entry) => {
         if (entry.isIntersecting && hasNextPage) {
-          debouncedLoadMore();
+          loadMoreAfterDebounce();
         }
       });
     });

--- a/frontend/src/components/ui/StationList/hooks/useFetchStationSummaries.ts
+++ b/frontend/src/components/ui/StationList/hooks/useFetchStationSummaries.ts
@@ -46,7 +46,6 @@ export const useFetchStationSummaries = (markers: StationMarker[]) => {
       setIsLoading(true);
       fetchStationSummaries(uncachedStationSummaryIds).then((stationSummaries) => {
         cachedStationSummariesActions.add(stationSummaries);
-        console.log(cachedStationSummariesActions.get());
         setIsLoading(false);
       });
     }


### PR DESCRIPTION
## 📄 Summary
> 이전과 다르게 더보기 버튼을 제거하였습니다.

최근 만들어 둔 충전소 리스트 캐싱 시스템이 안정적으로 잘 돌아가고 있고, 더이상 테스트를 진행하지 않아도 된다는 점도 고려하여 무한 스크롤로 대체하였습니다.

지하철에서 이동 중에 작업한거라 실수가 있을 수도 있으므로 꼼꼼히 검토 바랍니다.

현재 릴리즈 서버에 배포 해놨는데, 이상 없으면 그대로 스쿼시&머지 + 프로덕션까지 배포 해주셔도 됩니다.


- 무한 스크롤로 요청합니다.
- 사용자가 밑바닥 끝 까지 화면을 내리는 경우 다음 페이지에 대한 요청이 무한하게 들어가는 현상이 있어 서버 부담을 줄이기 위해 디바운스를 0.5 초로 걸어놨습니다.
- 단, 캐싱되어있는 데이터는 디바운스와 상관 없이 로드합니다. 신규 요청에 대해서만 디바운스가 적용됩니다.
- 리스트 끝에 가면 더이상 주변에 충전소가 존재하지 않는다는 문구가 출력됩니다.
- 불필요한 출력문 제거했습니다.

## 🕰️ Actual Time of Completion
> 30분

## 🙋🏻 More
> 


close #752