### PR TITLE
refactor: 모바일 환경에서 충전소 리스트를 클릭하는 경우, 상세보기가 바로 나오지 않고 인포 윈도우가 먼저 뜨도록 한다

### DIFF
--- a/frontend/src/components/ui/StationList/StationSummaryCard.tsx
+++ b/frontend/src/components/ui/StationList/StationSummaryCard.tsx
@@ -1,6 +1,7 @@
 import { css } from 'styled-components';
 
 import { useStationSummary } from '@hooks/google-maps/useStationSummary';
+import useMediaQueries from '@hooks/useMediaQueries';
 
 import Button from '@common/Button';
 import FlexBox from '@common/FlexBox';
@@ -20,8 +21,9 @@ interface Props {
 }
 
 const StationSummaryCard = ({ station, tag, $noPadding }: Props) => {
-  const { openLastPanel } = useNavigationBar();
+  const { openLastPanel, closeBasePanel } = useNavigationBar();
   const { openStationSummary } = useStationSummary();
+  const screen = useMediaQueries();
 
   const {
     stationId,
@@ -42,7 +44,11 @@ const StationSummaryCard = ({ station, tag, $noPadding }: Props) => {
         css={foundStationButton}
         onClick={() => {
           openStationSummary(stationId);
-          openLastPanel(<StationDetailsWindow stationId={stationId} />);
+          if (screen.get('isMobile')) {
+            closeBasePanel();
+          } else {
+            openLastPanel(<StationDetailsWindow stationId={stationId} />);
+          }
         }}
       >
         <FlexBox alignItems="start" justifyContent="between" nowrap columnGap={2.8}>


### PR DESCRIPTION
[#757]

## 📄 Summary
> 데스크톱 모드는 그대로입니다. 모바일 모드에서 충전소 리스트 카드를 클릭하는 경우, 상세정보가 열리지 않고 간단 정보가 뜨도록 수정하였습니다.

## 🕰️ Actual Time of Completion
> 10분

## 🙋🏻 More
> 


close #757