### PR TITLE
refactor: searchWord 전역 상태로 관리하지 않고 prop으로 넘겨주도록 개선한다

### DIFF
--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.stories.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.stories.tsx
@@ -76,10 +76,10 @@ export const Default = () => {
     event.preventDefault();
     handleCloseResult();
 
-    const directSearchedStations = await fetchSearchedStations(searchWord);
+    const searchedStations = await fetchSearchedStations(searchWord);
 
-    if (directSearchedStations !== undefined && directSearchedStations.length > 0) {
-      const [{ stationId, latitude, longitude }] = directSearchedStations;
+    if (searchedStations !== undefined && searchedStations.length > 0) {
+      const [{ stationId, latitude, longitude }] = searchedStations;
       showStationDetails({ stationId, latitude, longitude });
     }
 
@@ -91,9 +91,10 @@ export const Default = () => {
     openLastPanel(<StationDetailsWindow stationId={stationId} />);
   };
 
-  const handleRequestSearchResult = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+  const handleChangeSearchWord = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
     const searchWord = encodeURIComponent(value);
 
+    setIsFocused(true);
     setSearchWord(searchWord);
   };
 
@@ -107,7 +108,7 @@ export const Default = () => {
             role="searchbox"
             placeholder="충전소명 또는 지역명을 입력해 주세요"
             autoComplete="off"
-            onChange={handleRequestSearchResult}
+            onChange={handleChangeSearchWord}
             onFocus={handleOpenResult}
             onClick={handleOpenResult}
           />

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.stories.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.stories.tsx
@@ -2,14 +2,27 @@ import { MagnifyingGlassIcon } from '@heroicons/react/24/outline';
 import type { Meta } from '@storybook/react';
 import { styled } from 'styled-components';
 
-import type { ChangeEvent, FormEvent } from 'react';
+import type { ChangeEvent, FocusEvent, FormEvent, MouseEvent } from 'react';
 import { useState } from 'react';
 
-import { useSearchedStations } from '../../../hooks/tanstack-query/useSearchedStations';
-import { searchWordStore } from '../../../stores/searchWordStore';
+import { useQueryClient } from '@tanstack/react-query';
+
+import {
+  fetchSearchedStations,
+  useSearchedStations,
+} from '@hooks/tanstack-query/useSearchedStations';
+import { useDebounce } from '@hooks/useDebounce';
+
+import Loader from '@common/Loader';
+
+import StationDetailsWindow from '@ui/StationDetailsWindow';
+import { useNavigationBar } from '@ui/compound/NavigationBar/hooks/useNavigationBar';
+
+import { MOBILE_BREAKPOINT } from '@constants';
+import { QUERY_KEY_SEARCHED_STATION, QUERY_KEY_STATION_MARKERS } from '@constants/queryKeys';
+
 import { pillStyle } from '../../../style';
 import type { StationPosition } from '../../../types';
-import { useSetExternalState } from '../../../utils/external-state';
 import Button from '../../common/Button';
 import SearchResult from './SearchResult';
 
@@ -29,45 +42,81 @@ export default meta;
 // TODO: addon으로 googleMap 관련 함수 제외하기
 export const Default = () => {
   const [isFocused, setIsFocused] = useState(false);
-  const setSearchWord = useSetExternalState(searchWordStore);
 
-  const { data: stations, isLoading, isError } = useSearchedStations();
+  const [searchWord, setSearchWord] = useState('');
+  const [debouncedSearchWord, setDebouncedSearchWord] = useState(searchWord);
+  const queryClient = useQueryClient();
+  const { openLastPanel } = useNavigationBar();
 
-  const handleSubmitSearchWord = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  useDebounce(
+    () => {
+      setDebouncedSearchWord(searchWord);
+    },
+    [searchWord],
+    400
+  );
 
-    if (stations) {
-      const [{ stationId, latitude, longitude }] = stations;
-      showStationDetails({ stationId, latitude, longitude });
-    }
+  const {
+    data: stations,
+    isLoading,
+    isError,
+    isFetching,
+  } = useSearchedStations(debouncedSearchWord);
+
+  const handleOpenResult = (event: MouseEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>) => {
+    event.stopPropagation();
+    setIsFocused(true);
   };
 
-  const handleCloseResults = () => {
+  const handleCloseResult = () => {
     setIsFocused(false);
   };
 
+  const handleSubmitSearchWord = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    handleCloseResult();
+
+    const directSearchedStations = await fetchSearchedStations(searchWord);
+
+    if (directSearchedStations !== undefined && directSearchedStations.length > 0) {
+      const [{ stationId, latitude, longitude }] = directSearchedStations;
+      showStationDetails({ stationId, latitude, longitude });
+    }
+
+    queryClient.invalidateQueries({ queryKey: [QUERY_KEY_SEARCHED_STATION] });
+  };
+
   const showStationDetails = ({ stationId, latitude, longitude }: StationPosition) => {
-    alert('충전소 간단 정보, 상세 정보를 보여준다.');
+    queryClient.invalidateQueries({ queryKey: [QUERY_KEY_STATION_MARKERS] });
+    openLastPanel(<StationDetailsWindow stationId={stationId} />);
   };
 
   const handleRequestSearchResult = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
     const searchWord = encodeURIComponent(value);
+
     setSearchWord(searchWord);
   };
 
   return (
-    <>
+    <S.Container>
       <S.Form role="search" onSubmit={handleSubmitSearchWord}>
-        <label htmlFor="station-search-bar">
+        <label htmlFor="station-search-bar" aria-hidden>
           <S.Search
+            id="station-search-bar"
             type="search"
             role="searchbox"
+            placeholder="충전소명 또는 지역명을 입력해 주세요"
+            autoComplete="off"
             onChange={handleRequestSearchResult}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => setIsFocused(false)}
+            onFocus={handleOpenResult}
+            onClick={handleOpenResult}
           />
           <Button type="submit" aria-label="검색하기">
-            <MagnifyingGlassIcon width="2.4rem" stroke="#767676" />
+            {isFetching ? (
+              <Loader size="md" />
+            ) : (
+              <MagnifyingGlassIcon width="2.4rem" stroke="#767676" />
+            )}
           </Button>
         </label>
       </S.Form>
@@ -77,26 +126,40 @@ export const Default = () => {
           isLoading={isLoading}
           isError={isError}
           showStationDetails={showStationDetails}
-          closeResult={handleCloseResults}
+          closeResult={handleCloseResult}
         />
       )}
-    </>
+    </S.Container>
   );
 };
+
 const S = {
+  Container: styled.div`
+    width: 30rem;
+
+    @media screen and (max-width: ${MOBILE_BREAKPOINT}px) {
+      width: 100%;
+    }
+  `,
+
   Form: styled.form`
     position: relative;
+    min-width: 30rem;
+
+    @media screen and (max-width: ${MOBILE_BREAKPOINT}px) {
+      min-width: 100%;
+    }
   `,
 
   Search: styled.input`
-    ${pillStyle};
+    ${pillStyle}
 
     background: #fcfcfc;
     border: 1px solid #d0d2d8;
 
     width: 100%;
     padding: 1.9rem 4.6rem 2rem 1.8rem;
-    font-size: 1.5rem;
+    font-size: 1.3rem;
 
     & + button {
       position: absolute;
@@ -108,15 +171,6 @@ const S = {
     &:focus {
       box-shadow: 0 1px 8px 0 rgba(0, 0, 0, 0.2);
       outline: 0;
-    }
-  `,
-
-  Container: styled.div`
-    width: 34rem;
-    margin-bottom: 2rem;
-
-    &:last-child {
-      margin-bottom: 0;
     }
   `,
 };

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -12,7 +12,6 @@ import { useExternalValue, useSetExternalState } from '@utils/external-state';
 
 import { getGoogleMapStore } from '@stores/google-maps/googleMapStore';
 import { markerInstanceStore } from '@stores/google-maps/markerInstanceStore';
-import { searchWordStore } from '@stores/searchWordStore';
 
 import { fetchStationSummaries } from '@hooks/fetch/fetchStationSummaries';
 import { useStationSummary } from '@hooks/google-maps/useStationSummary';
@@ -39,8 +38,8 @@ const StationSearchBar = () => {
   const [isFocused, setIsFocused] = useState(false);
   const googleMap = useExternalValue(getGoogleMapStore());
 
-  const [inputValue, setInputValue] = useState('');
-  const setSearchWord = useSetExternalState(searchWordStore);
+  const [searchWord, setSearchWord] = useState('');
+  const [debouncedSearchWord, setDebouncedSearchWord] = useState(searchWord);
   const queryClient = useQueryClient();
   const { openLastPanel } = useNavigationBar();
   const { openStationSummary } = useStationSummary();
@@ -49,13 +48,18 @@ const StationSearchBar = () => {
 
   useDebounce(
     () => {
-      setSearchWord(inputValue);
+      setDebouncedSearchWord(searchWord);
     },
-    [inputValue],
+    [searchWord],
     400
   );
 
-  const { data: stations, isLoading, isError, isFetching } = useSearchedStations();
+  const {
+    data: stations,
+    isLoading,
+    isError,
+    isFetching,
+  } = useSearchedStations(debouncedSearchWord);
 
   const handleOpenResult = (event: MouseEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>) => {
     event.stopPropagation();
@@ -110,7 +114,7 @@ const StationSearchBar = () => {
   const handleRequestSearchResult = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
     const searchWord = encodeURIComponent(value);
 
-    setInputValue(searchWord);
+    setSearchWord(searchWord);
   };
 
   return (

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -126,6 +126,7 @@ const StationSearchBar = () => {
             type="search"
             role="searchbox"
             placeholder="충전소명 또는 지역명을 입력해 주세요"
+            autoComplete="off"
             onChange={handleRequestSearchResult}
             onFocus={handleOpenResult}
             onClick={handleOpenResult}

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -15,7 +15,10 @@ import { markerInstanceStore } from '@stores/google-maps/markerInstanceStore';
 
 import { fetchStationSummaries } from '@hooks/fetch/fetchStationSummaries';
 import { useStationSummary } from '@hooks/google-maps/useStationSummary';
-import { useSearchedStations } from '@hooks/tanstack-query/useSearchedStations';
+import {
+  fetchSearchedStations,
+  useSearchedStations,
+} from '@hooks/tanstack-query/useSearchedStations';
 import { useDebounce } from '@hooks/useDebounce';
 
 import Button from '@common/Button';
@@ -70,12 +73,14 @@ const StationSearchBar = () => {
     setIsFocused(false);
   };
 
-  const handleSubmitSearchWord = (event: FormEvent<HTMLFormElement>) => {
+  const handleSubmitSearchWord = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     handleCloseResult();
 
-    if (stations !== undefined && stations.length > 0) {
-      const [{ stationId, latitude, longitude }] = stations;
+    const directSearchedStations = await fetchSearchedStations(searchWord);
+
+    if (directSearchedStations !== undefined && directSearchedStations.length > 0) {
+      const [{ stationId, latitude, longitude }] = directSearchedStations;
       showStationDetails({ stationId, latitude, longitude });
     }
 

--- a/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
+++ b/frontend/src/components/ui/StationSearchWindow/StationSearchBar.tsx
@@ -77,10 +77,10 @@ const StationSearchBar = () => {
     event.preventDefault();
     handleCloseResult();
 
-    const directSearchedStations = await fetchSearchedStations(searchWord);
+    const searchedStations = await fetchSearchedStations(searchWord);
 
-    if (directSearchedStations !== undefined && directSearchedStations.length > 0) {
-      const [{ stationId, latitude, longitude }] = directSearchedStations;
+    if (searchedStations !== undefined && searchedStations.length > 0) {
+      const [{ stationId, latitude, longitude }] = searchedStations;
       showStationDetails({ stationId, latitude, longitude });
     }
 
@@ -117,9 +117,10 @@ const StationSearchBar = () => {
     });
   };
 
-  const handleRequestSearchResult = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
+  const handleChangeSearchWord = ({ target: { value } }: ChangeEvent<HTMLInputElement>) => {
     const searchWord = encodeURIComponent(value);
 
+    setIsFocused(true);
     setSearchWord(searchWord);
   };
 
@@ -133,7 +134,7 @@ const StationSearchBar = () => {
             role="searchbox"
             placeholder="충전소명 또는 지역명을 입력해 주세요"
             autoComplete="off"
-            onChange={handleRequestSearchResult}
+            onChange={handleChangeSearchWord}
             onFocus={handleOpenResult}
             onClick={handleOpenResult}
           />

--- a/frontend/src/hooks/tanstack-query/useSearchedStations.ts
+++ b/frontend/src/hooks/tanstack-query/useSearchedStations.ts
@@ -1,9 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { useExternalValue } from '@utils/external-state';
-
 import { serverUrlStore } from '@stores/config/serverUrlStore';
-import { searchWordStore } from '@stores/searchWordStore';
 
 import { ERROR_MESSAGES } from '@constants/errorMessages';
 import { QUERY_KEY_SEARCHED_STATION } from '@constants/queryKeys';
@@ -35,9 +32,7 @@ export const fetchSearchedStations = async (searchWord: string) => {
   return searchedStations;
 };
 
-export const useSearchedStations = () => {
-  const searchWord = useExternalValue(searchWordStore);
-
+export const useSearchedStations = (searchWord: string) => {
   return useQuery({
     queryKey: [QUERY_KEY_SEARCHED_STATION, searchWord],
     queryFn: () => fetchSearchedStations(searchWord),

--- a/frontend/src/stores/searchWordStore.ts
+++ b/frontend/src/stores/searchWordStore.ts
@@ -1,3 +1,0 @@
-import { store } from '@utils/external-state';
-
-export const searchWordStore = store<string>(null);


### PR DESCRIPTION
[#767]

## 📄 Summary

> searchWord 전역 상태로 관리하지 않고 prop으로 넘겨주도록 개선한다

## 🕰️ Actual Time of Completion

> 20분

## 🙋🏻 More

>

## 🚀 Storybook

> https://storybook.carffe.in/
