### PR TITLE
design: 높아진 NavBar 크기에 맞춰 맵 컨트롤러 등을 위로 올린다

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -47,6 +47,7 @@
     <link href="https://fonts.googleapis.com" rel="preconnect" />
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect" />
     <link
+      as="font"
       href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap"
       rel="preload"
       type="font/woff2"

--- a/frontend/src/components/common/Toast/ToastContainer.tsx
+++ b/frontend/src/components/common/Toast/ToastContainer.tsx
@@ -8,13 +8,7 @@ import Toast from './Toast';
 const ToastContainer = () => {
   const toastItems = useExternalValue<ToastProps[]>(toastListStore);
 
-  return (
-    <>
-      {toastItems.map((toastItem) => (
-        <Toast key={toastItem.toastId} {...toastItem} />
-      ))}
-    </>
-  );
+  return toastItems.map((toastItem) => <Toast key={toastItem.toastId} {...toastItem} />);
 };
 
 export default ToastContainer;

--- a/frontend/src/components/ui/MapController.tsx
+++ b/frontend/src/components/ui/MapController.tsx
@@ -76,7 +76,7 @@ const containerCss = css`
   width: 4.2rem;
 
   @media screen and (max-width: ${MOBILE_BREAKPOINT}px) {
-    bottom: 8rem;
+    bottom: 9.6rem;
     right: 0.8rem;
   }
 `;

--- a/frontend/src/components/ui/compound/PopupMenu/index.tsx
+++ b/frontend/src/components/ui/compound/PopupMenu/index.tsx
@@ -53,7 +53,7 @@ const container = css`
     top: -18px;
 
     @media screen and (max-width: ${MOBILE_BREAKPOINT}px) {
-      top: -102px;
+      top: -96px;
       left: -43px;
     }
   }

--- a/frontend/src/style/index.ts
+++ b/frontend/src/style/index.ts
@@ -116,10 +116,10 @@ const popup = (position: ToastPositionProps = 'bottom-center') => {
   return css`
     @keyframes PopUp {
       from {
-        ${row === 'center' ? `${column}: 0; left: 50%;` : `${column}: 10%; ${row}: 0;`}
+        ${row === 'center' ? `${column}: 0; left: 50%;` : `${column}: 12%; ${row}: 0;`}
       }
       to {
-        ${column}: 10%;
+        ${column}: 12%;
         left: 50%;
         transform: translateX(-50%);
       }


### PR DESCRIPTION
[#778]

## 📄 Summary

> 높아진 NavBar 크기에 맞춰 맵 컨트롤러 등을 위로 올린다

<img width="246" alt="스크린샷 2023-09-22 000109" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/76bfb01a-369a-4108-971a-c0b689bbbcca">

<img width="239" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/7799bd08-220d-4a64-883a-5b097c9a68fa">


## 🕰️ Actual Time of Completion

> 10분

## 🙋🏻 More

>


## 🚀 Storybook 

> https://storybook.carffe.in/