### PR TITLE
design: 메뉴창 버튼 디자인을 개선한다

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -47,7 +47,7 @@
     <link href="https://fonts.googleapis.com" rel="preconnect" />
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect" />
     <link
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
     <title>카페인</title>

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -47,11 +47,8 @@
     <link href="https://fonts.googleapis.com" rel="preconnect" />
     <link crossorigin href="https://fonts.gstatic.com" rel="preconnect" />
     <link
-      as="font"
-      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap"
-      rel="preload"
-      type="font/woff2"
-      crossorigin
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@100;300;400;500;700;900&display=swap"
+      rel="stylesheet"
     />
     <title>카페인</title>
   </head>

--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -93,7 +93,7 @@ const labelButtonStyle = css`
   position: absolute;
   top: 1.2rem;
   right: -3.8rem;
-  height: 7.8rem;
+  height: 7.6rem;
   padding: 0 0.6rem 0 0.4rem;
   background: #fcfcfc;
   border: 2.2px solid #e1e4eb;

--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -92,11 +92,11 @@ const S = {
 const labelButtonStyle = css`
   position: absolute;
   top: 1.2rem;
-  right: -3.37rem;
-  height: 6.2rem;
-  padding: 0 0.6rem 0 0.2rem;
+  right: -3.8rem;
+  height: 7.8rem;
+  padding: 0 0.6rem 0 0.4rem;
   background: #fcfcfc;
-  border: 1.5px solid #e1e4eb;
+  border: 2.2px solid #e1e4eb;
   border-left: 0.2px solid #e1e4eb;
 
   ${borderRadius('left')}

--- a/frontend/src/components/ui/compound/NavigationBar/CloseButton.tsx
+++ b/frontend/src/components/ui/compound/NavigationBar/CloseButton.tsx
@@ -1,5 +1,4 @@
 import { ChevronLeftIcon } from '@heroicons/react/24/solid';
-import { css } from 'styled-components';
 
 import Button from '@common/Button';
 
@@ -25,7 +24,7 @@ const CloseButton = ({ canDisplay }: Props) => {
       aria-label="검색창 닫기"
       onClick={handleClosePanel}
     >
-      <ChevronLeftIcon width="2.4rem" stroke="#9c9fa7" />
+      <ChevronLeftIcon width="2.4rem" fill="#5b5d62" stroke="#5b5d62" />
     </Button>
   );
 };

--- a/frontend/src/components/ui/compound/NavigationBar/Menu.tsx
+++ b/frontend/src/components/ui/compound/NavigationBar/Menu.tsx
@@ -37,11 +37,21 @@ const Menu = () => {
 
   return (
     <FlexBox css={[fixedPositionCss, paddingCss, borderCss, flexCss]} noRadius="all" nowrap>
-      <Button css={displayNoneInMobile} aria-label="새로 고침" onClick={() => location.reload()}>
+      <Button
+        noRadius="all"
+        css={displayNoneInMobile}
+        aria-label="새로 고침"
+        onClick={() => location.reload()}
+      >
         <LogoIcon width={3} />
       </Button>
 
-      <Button css={displayNoneInWeb} aria-label="새로 고침" onClick={() => location.reload()}>
+      <Button
+        noRadius="all"
+        css={displayNoneInWeb}
+        aria-label="새로 고침"
+        onClick={() => location.reload()}
+      >
         <HiArrowPath size="2.8rem" fill="#555" />
         <Text mt={0.5} variant="caption">
           새로고침
@@ -49,6 +59,7 @@ const Menu = () => {
       </Button>
 
       <Button
+        noRadius="all"
         css={displayNoneInMobile}
         aria-label="주변 충전소 목록 열기"
         onClick={() => openBasePanel(<StationSearchWindow />)}
@@ -59,7 +70,11 @@ const Menu = () => {
         </Text>
       </Button>
 
-      <Button aria-label="필터링 메뉴 열기" onClick={() => openBasePanel(<ServerStationFilters />)}>
+      <Button
+        noRadius="all"
+        aria-label="필터링 메뉴 열기"
+        onClick={() => openBasePanel(<ServerStationFilters />)}
+      >
         <AdjustmentsHorizontalIcon width="2.8rem" stroke="#555" />
         <Text mt={0.5} variant="caption">
           필터
@@ -69,7 +84,7 @@ const Menu = () => {
       {isSignIn ? (
         <PersonalMenu />
       ) : (
-        <Button aria-label="로그인 하기" onClick={handleClickLoginIcon}>
+        <Button noRadius="all" aria-label="로그인 하기" onClick={handleClickLoginIcon}>
           <UserCircleIcon width="2.8rem" stroke="#555" />
           <Text mt={0.5} variant="caption">
             내정보
@@ -78,6 +93,7 @@ const Menu = () => {
       )}
 
       <Button
+        noRadius="all"
         css={displayNoneInWeb}
         aria-label="충전소 리스트 열기"
         onClick={() => openBasePanel(<StationListWindow />)}
@@ -89,6 +105,7 @@ const Menu = () => {
       </Button>
 
       <Button
+        noRadius="all"
         aria-label="설문조사 하기"
         onClick={() => {
           if (confirm('설문조사에 참여하시겠습니까?')) {


### PR DESCRIPTION
## 📄 Summary

> 메뉴창 버튼 디자인을 개선했습니다. 
- 크기를 키움
- 화살표 아이콘 색깔을 더 진하게 함

<img width="1280" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/d28e81da-517d-4621-8c17-147a19f3832a">


🚨 fix: 폰트 개선을 하면서 모바일에서 패딩이 좁아지거나 하는 문제가 생겨 preload를 제거했습니다.

## 🕰️ Actual Time of Completion

> 20분

## 🚀 Storybook
> https://storybook.carffe.in/

close #793