### PR TITLE
refactor: 완속 충전기만 있거나 급속 충전기만 있는 충전소는 혼잡도 완속/급속 버튼을 없앤다

### DIFF
--- a/frontend/src/components/common/Button/Button.tsx
+++ b/frontend/src/components/common/Button/Button.tsx
@@ -92,7 +92,7 @@ const S = {
 const labelButtonStyle = css`
   position: absolute;
   top: 1.2rem;
-  right: -3.8rem;
+  right: -3.68rem;
   height: 7.6rem;
   padding: 0 0.6rem 0 0.4rem;
   background: #fcfcfc;

--- a/frontend/src/components/ui/StationDetailsWindow/chargers/ChargerCard.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/chargers/ChargerCard.tsx
@@ -5,7 +5,11 @@ import { calculateLatestUpdateTime } from '@utils/index';
 import FlexBox from '@common/FlexBox';
 import Text from '@common/Text';
 
-import { CHARGER_STATES, CONNECTOR_TYPES } from '@constants/chargers';
+import {
+  CHARGER_STATES,
+  CONNECTOR_TYPES,
+  QUICK_CHARGER_CAPACITY_THRESHOLD,
+} from '@constants/chargers';
 
 import type { ChargerDetails, ChargerStateType } from '@type/chargers';
 
@@ -48,7 +52,7 @@ const ChargerCard = ({ charger }: ChargerCardProps) => {
         {CONNECTOR_TYPES[type]}
       </Text>
       <Text my={0} variant="label">
-        {capacity >= 50 ? '급속' : '완속'}({capacity}kW)
+        {capacity >= QUICK_CHARGER_CAPACITY_THRESHOLD ? '급속' : '완속'}({capacity}kW)
         {method && (
           <Text tag="span" variant="label" my={1}>
             &nbsp;/&nbsp;{method}

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/CongestionBarContainerSkeleton.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/CongestionBarContainerSkeleton.tsx
@@ -12,7 +12,7 @@ const CongestionBarContainerSkeleton = () => {
         {Array.from({ length: 24 }, (_, index) => (
           <Box key={index} css={graphCss}>
             <Text variant="caption">{String(index + 1).padStart(2, '0')}</Text>
-            <Skeleton width="90%" height="1.2rem" />
+            <Skeleton borderRadius="4px 10px 10px 4px" width="92.5%" height="1.2rem" />
           </Box>
         ))}
       </FlexBox>

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/CongestionStatistics.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/CongestionStatistics.tsx
@@ -4,7 +4,7 @@ import Box from '@common/Box';
 
 import { ENGLISH_DAYS_OF_WEEK } from '@constants/congestion';
 
-import type { LongEnglishDaysOfWeek } from '@type';
+import type { EnglishDaysOfWeek } from '@type';
 
 import Statistics from './Statistics';
 import Title from './Title';
@@ -15,7 +15,7 @@ interface CongestionStatisticsProps {
 
 const CongestionStatistics = ({ stationId }: CongestionStatisticsProps) => {
   const todayIndex = new Date().getDay() - 1;
-  const [dayOfWeek, setDayOfWeek] = useState<LongEnglishDaysOfWeek>(
+  const [dayOfWeek, setDayOfWeek] = useState<EnglishDaysOfWeek>(
     ENGLISH_DAYS_OF_WEEK[todayIndex < 0 ? 6 : todayIndex]
   );
 

--- a/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
+++ b/frontend/src/components/ui/StationDetailsWindow/congestion/Statistics.tsx
@@ -11,12 +11,12 @@ import StatisticsGraph from '@ui/StatisticsGraph';
 import type { CHARGING_SPEED } from '@constants/chargers';
 import { SHORT_ENGLISH_DAYS_OF_WEEK } from '@constants/congestion';
 
-import type { LongEnglishDaysOfWeek } from '@type';
+import type { EnglishDaysOfWeek } from '@type';
 
 interface Props {
   stationId: string;
-  dayOfWeek: LongEnglishDaysOfWeek;
-  onChangeDayOfWeek: (dayOfWeek: LongEnglishDaysOfWeek) => void;
+  dayOfWeek: EnglishDaysOfWeek;
+  onChangeDayOfWeek: (dayOfWeek: EnglishDaysOfWeek) => void;
 }
 
 const Statistics = ({ stationId, dayOfWeek, onChangeDayOfWeek }: Props) => {

--- a/frontend/src/components/ui/StatisticsGraph/index.tsx
+++ b/frontend/src/components/ui/StatisticsGraph/index.tsx
@@ -2,11 +2,11 @@ import type { GraphProps } from '@ui/compound/Graph';
 import Graph from '@ui/compound/Graph';
 import type { DayMenusProps } from '@ui/compound/Graph/DayMenus';
 
-import type { Congestion, LongEnglishDaysOfWeek } from '@type';
+import type { Congestion, EnglishDaysOfWeek } from '@type';
 
 interface Props extends GraphProps, Omit<DayMenusProps, 'renderMenuSelectButton'> {
-  dayOfWeek: LongEnglishDaysOfWeek;
-  onChangeDayOfWeek: (dayOfWeek: LongEnglishDaysOfWeek) => void;
+  dayOfWeek: EnglishDaysOfWeek;
+  onChangeDayOfWeek: (dayOfWeek: EnglishDaysOfWeek) => void;
   isLoading: boolean;
   statistics: Congestion[];
 }

--- a/frontend/src/components/ui/compound/Graph/CircleDaySelectButton.tsx
+++ b/frontend/src/components/ui/compound/Graph/CircleDaySelectButton.tsx
@@ -11,11 +11,11 @@ import {
   ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT,
 } from '@constants/congestion';
 
-import type { LongEnglishDaysOfWeek, ShortEnglishDaysOfWeek } from '@type/congestion';
+import type { EnglishDaysOfWeek, ShortEnglishDaysOfWeek } from '@type/congestion';
 
 interface DaySelectButtonProps extends PropsWithChildren {
-  dayOfWeek: LongEnglishDaysOfWeek;
-  onChangeDayOfWeek: (dayOfWeek: LongEnglishDaysOfWeek) => void;
+  dayOfWeek: EnglishDaysOfWeek;
+  onChangeDayOfWeek: (dayOfWeek: EnglishDaysOfWeek) => void;
 }
 
 const isEnglishDays = (day: string): day is ShortEnglishDaysOfWeek => {

--- a/frontend/src/components/ui/compound/Graph/CircleDaySelectButton.tsx
+++ b/frontend/src/components/ui/compound/Graph/CircleDaySelectButton.tsx
@@ -6,9 +6,9 @@ import ButtonNext from '@common/ButtonNext';
 
 import {
   SHORT_ENGLISH_DAYS_OF_WEEK,
-  ENGLISH_DAYS_OF_WEEK_SHORT_TO_LONG,
+  ENGLISH_DAYS_OF_WEEK_SHORT_TO_FULL,
   ENGLISH_DAYS_TO_KOREAN_DAYS,
-  ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT,
+  ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT,
 } from '@constants/congestion';
 
 import type { EnglishDaysOfWeek, ShortEnglishDaysOfWeek } from '@type/congestion';
@@ -30,7 +30,7 @@ const CircleDaySelectButton = ({
   const handleSelectDay = (day: string) => {
     if (isEnglishDays(day)) {
       onChangeDayOfWeek(
-        ENGLISH_DAYS_OF_WEEK_SHORT_TO_LONG[day as (typeof SHORT_ENGLISH_DAYS_OF_WEEK)[number]]
+        ENGLISH_DAYS_OF_WEEK_SHORT_TO_FULL[day as (typeof SHORT_ENGLISH_DAYS_OF_WEEK)[number]]
       );
     }
   };
@@ -39,9 +39,9 @@ const CircleDaySelectButton = ({
     <ButtonNext
       size="sm"
       variant={
-        ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT[dayOfWeek] === children ? 'contained' : 'outlined'
+        ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT[dayOfWeek] === children ? 'contained' : 'outlined'
       }
-      css={[buttonCss, ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT[dayOfWeek] === children && colorCss]}
+      css={[buttonCss, ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT[dayOfWeek] === children && colorCss]}
       onClick={() => {
         if (typeof children === 'string') {
           handleSelectDay(children);

--- a/frontend/src/constants/chargers.ts
+++ b/frontend/src/constants/chargers.ts
@@ -132,6 +132,7 @@ export const COMPANIES = {
 
 // 충전 속도
 export const CAPACITIES = [3, 7, 50, 100, 200] as const;
+export const QUICK_CHARGER_CAPACITY_THRESHOLD = 50;
 
 export const CHARGING_SPEED = {
   quick: '급속',

--- a/frontend/src/constants/congestion.ts
+++ b/frontend/src/constants/congestion.ts
@@ -23,11 +23,11 @@ export const ENGLISH_DAYS_TO_KOREAN_DAYS = getTypedObjectFromEntries(
   SHORT_ENGLISH_DAYS_OF_WEEK,
   SHORT_KOREAN_DAYS_OF_WEEK
 );
-export const ENGLISH_DAYS_OF_WEEK_SHORT_TO_LONG = getTypedObjectFromEntries(
+export const ENGLISH_DAYS_OF_WEEK_SHORT_TO_FULL = getTypedObjectFromEntries(
   SHORT_ENGLISH_DAYS_OF_WEEK,
   ENGLISH_DAYS_OF_WEEK
 );
-export const ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT = Object.fromEntries(
+export const ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT = Object.fromEntries(
   ENGLISH_DAYS_OF_WEEK.map((day, index) => [day, SHORT_ENGLISH_DAYS_OF_WEEK[index]])
 );
 

--- a/frontend/src/hooks/tanstack-query/station-details/useStationCongestionStatistics.ts
+++ b/frontend/src/hooks/tanstack-query/station-details/useStationCongestionStatistics.ts
@@ -5,7 +5,7 @@ import { serverUrlStore } from '@stores/config/serverUrlStore';
 import { ERROR_MESSAGES } from '@constants/errorMessages';
 import { QUERY_KEY_STATION_CONGESTION_STATISTICS } from '@constants/queryKeys';
 
-import type { CongestionStatistics, LongEnglishDaysOfWeek } from '@type/congestion';
+import type { CongestionStatistics, EnglishDaysOfWeek } from '@type/congestion';
 
 export const fetchStationDetails = async (selectedStationId: string, dayOfWeek: string) => {
   const serverUrl = serverUrlStore.getState();
@@ -28,10 +28,7 @@ export const fetchStationDetails = async (selectedStationId: string, dayOfWeek: 
   return stationDetails;
 };
 
-export const useStationCongestionStatistics = (
-  stationId: string,
-  dayOfWeek: LongEnglishDaysOfWeek
-) => {
+export const useStationCongestionStatistics = (stationId: string, dayOfWeek: EnglishDaysOfWeek) => {
   return useQuery({
     queryKey: [QUERY_KEY_STATION_CONGESTION_STATISTICS, stationId, dayOfWeek],
     queryFn: () => fetchStationDetails(stationId, dayOfWeek),

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -46,7 +46,7 @@ const generateRandomStationId = () => {
   return `${randomLetter1}${randomLetter2}${randomNumber}`;
 };
 
-export const stations: Station[] = Array.from({ length: 60000 }, (_, index) => {
+export const stations: Station[] = Array.from({ length: 60000 }, () => {
   const randomStationId = generateRandomStationId();
   const chargers = generateRandomChargers();
   const totalCount = chargers.length;

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -2,8 +2,13 @@ import { getTypedObjectFromEntries } from '@utils/getTypedObjectFromEntries';
 import { getTypedObjectKeys } from '@utils/getTypedObjectKeys';
 import { generateRandomData, generateRandomToken, getRandomTime } from '@utils/randomDataGenerator';
 
-import { CONNECTOR_TYPES, COMPANIES, CAPACITIES } from '@constants/chargers';
-import { SHORT_ENGLISH_DAYS_OF_WEEK } from '@constants/congestion';
+import {
+  CONNECTOR_TYPES,
+  COMPANIES,
+  CAPACITIES,
+  QUICK_CHARGER_CAPACITY_THRESHOLD,
+} from '@constants/chargers';
+import { NO_RATIO, SHORT_ENGLISH_DAYS_OF_WEEK } from '@constants/congestion';
 import { MAX_SEARCH_RESULTS } from '@constants/stationSearch';
 
 import type { Car } from '@type/cars';
@@ -51,7 +56,9 @@ export const stations: Station[] = Array.from({ length: 60000 }, () => {
   const chargers = generateRandomChargers();
   const totalCount = chargers.length;
   const availableCount = chargers.filter(({ state }) => state === 'STANDBY').length;
-  const quickChargerCount = chargers.filter(({ capacity }) => capacity >= 50).length;
+  const quickChargerCount = chargers.filter(
+    ({ capacity }) => capacity >= QUICK_CHARGER_CAPACITY_THRESHOLD
+  ).length;
 
   return {
     stationId: randomStationId,
@@ -89,7 +96,9 @@ export const getSearchedStations = (searchWord: string) => {
     const { stationId, stationName, chargers, address, latitude, longitude } = station;
 
     const onlyCapacity = chargers.map(({ capacity }) => capacity);
-    const speed = onlyCapacity.map((num) => (num >= 50 ? 'QUICK' : 'STANDARD'));
+    const speed = onlyCapacity.map((num) =>
+      num >= QUICK_CHARGER_CAPACITY_THRESHOLD ? 'QUICK' : 'STANDARD'
+    );
 
     return { stationId, stationName, speed, address, latitude, longitude };
   });
@@ -110,7 +119,9 @@ interface CongestionStatisticsMockData {
 export const getCongestionStatistics = (stationId: string): CongestionStatisticsMockData => {
   const foundStation = stations.find((station) => station.stationId === stationId);
   const hasOnlyStandardChargers = foundStation.quickChargerCount === 0;
-  const hasOnlyQuickChargers = foundStation.chargers.every(({ capacity }) => capacity >= 50);
+  const hasOnlyQuickChargers = foundStation.chargers.every(
+    ({ capacity }) => capacity >= QUICK_CHARGER_CAPACITY_THRESHOLD
+  );
 
   return {
     stationId: foundStation.stationId,
@@ -130,7 +141,7 @@ const getCongestions = (
       Array.from({ length: 24 }, (_, index) => {
         return {
           hour: index,
-          ratio: hasOnlyOneChargerType || Math.random() > 0.95 ? -1 : Math.random(),
+          ratio: hasOnlyOneChargerType || Math.random() > 0.95 ? NO_RATIO : Math.random(),
         };
       })
     )

--- a/frontend/src/mocks/data.ts
+++ b/frontend/src/mocks/data.ts
@@ -108,23 +108,29 @@ interface CongestionStatisticsMockData {
 }
 
 export const getCongestionStatistics = (stationId: string): CongestionStatisticsMockData => {
+  const foundStation = stations.find((station) => station.stationId === stationId);
+  const hasOnlyStandardChargers = foundStation.quickChargerCount === 0;
+  const hasOnlyQuickChargers = foundStation.chargers.every(({ capacity }) => capacity >= 50);
+
   return {
-    stationId,
+    stationId: foundStation.stationId,
     congestion: {
-      quick: getCongestions(),
-      standard: getCongestions(),
+      quick: getCongestions(hasOnlyStandardChargers),
+      standard: getCongestions(hasOnlyQuickChargers),
     },
   };
 };
 
-const getCongestions = (): Record<ShortEnglishDaysOfWeek, Congestion[]> => {
+const getCongestions = (
+  hasOnlyOneChargerType: boolean
+): Record<ShortEnglishDaysOfWeek, Congestion[]> => {
   return getTypedObjectFromEntries(
     SHORT_ENGLISH_DAYS_OF_WEEK,
     SHORT_ENGLISH_DAYS_OF_WEEK.map(() =>
       Array.from({ length: 24 }, (_, index) => {
         return {
           hour: index,
-          ratio: Math.random() > 0.95 ? -1 : Math.random(),
+          ratio: hasOnlyOneChargerType || Math.random() > 0.95 ? -1 : Math.random(),
         };
       })
     )

--- a/frontend/src/mocks/handlers/station-details/statisticsHandlers.ts
+++ b/frontend/src/mocks/handlers/station-details/statisticsHandlers.ts
@@ -1,7 +1,7 @@
 import { getCongestionStatistics } from '@mocks/data';
 import { rest } from 'msw';
 
-import { ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT } from '@constants/congestion';
+import { ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT } from '@constants/congestion';
 import { DEVELOP_SERVER_URL } from '@constants/server';
 
 import type { ShortEnglishDaysOfWeek } from '@type';
@@ -20,12 +20,12 @@ export const statisticsHandlers = [
       congestion: {
         standard: [
           ...fullCongestionStatistics['congestion']['standard'][
-            ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT[dayOfWeek]
+            ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT[dayOfWeek]
           ],
         ],
         quick: [
           ...fullCongestionStatistics['congestion']['quick'][
-            ENGLISH_DAYS_OF_WEEK_LONG_TO_SHORT[dayOfWeek]
+            ENGLISH_DAYS_OF_WEEK_FULL_TO_SHORT[dayOfWeek]
           ],
         ],
       },

--- a/frontend/src/style/reset.ts
+++ b/frontend/src/style/reset.ts
@@ -87,7 +87,16 @@ export const reset = css`
 
   input::-moz-focus-inner {
     border: 0; 
-    padding: 0; 
+    padding: 0;
     margin: 0;
   }
+
+  progress {
+    border: none;
+    box-shadow: none;
+  }
+  progress[value] { 
+    -webkit-appearance: none; 
+    appearance: none;
+  } 
 `

--- a/frontend/src/types/congestion.ts
+++ b/frontend/src/types/congestion.ts
@@ -5,7 +5,7 @@ import type {
 } from '@constants/congestion';
 
 export type ShortEnglishDaysOfWeek = (typeof SHORT_ENGLISH_DAYS_OF_WEEK)[number];
-export type LongEnglishDaysOfWeek = (typeof ENGLISH_DAYS_OF_WEEK)[number];
+export type EnglishDaysOfWeek = (typeof ENGLISH_DAYS_OF_WEEK)[number];
 export type KoreanDaysOfWeek = (typeof SHORT_KOREAN_DAYS_OF_WEEK)[number];
 
 export interface Congestion {


### PR DESCRIPTION
## 📄 Summary
- 1. firefox에서 보이는 Progress Bar의 border 제거했습니다.

![image](https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/7a002694-41dc-4147-a2dd-9a8f1f8a0b8e)

위 사진에서 보이는 회색 border는 이제 더 이상 보이지 않습니다.

- 2. 완속 충전기만 있거나 급속 충전기만 있는 충전소는 혼잡도 완속/급속 버튼을 없앴습니다.

<img width="176" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/b267d8ad-8bc6-42fc-b70d-9ce5230f9674">
<img width="171" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/f00db1a2-ebba-4dc4-80f3-7755d294a821">
<img width="183" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/108778921/98bc15cc-a648-4549-9a34-5280b1ea1e39">

- 3. msw에서 완속 충전기만 있는데 급속 충전기의 혼잡도도 보이는 문제 개선했습니다.
  -> 완속 충전기만 있으면 급속 충전기의 혼잡도 모두 -1 (ratio), 급속 충전기만 있으면 완속 충전기의 혼잡도 모두 -1

- 4. 예전에 상수명 LongEngDays -> EngDays로 바꿨는데, 타입명은 여전히 안 바뀌어 있길래 타입명 수정했습니다.
- 5. 급속 충전기 기준 상수화했습니다. (QUICK_CHARGER_CAPACITY_THRESHOLD)

## 🕰️ Actual Time of Completion

> 2시간

## 🙋🏻 More

>


close #799

## 🚀 Storybook 

> https://storybook.carffe.in/