### PR TITLE
fix: 대도시 마커 렌더링 오류를 수정한다

### DIFF
--- a/frontend/src/components/google-maps/marker/MaxDeltaAreaMarkerContainer/hooks/useRegionMarkers.ts
+++ b/frontend/src/components/google-maps/marker/MaxDeltaAreaMarkerContainer/hooks/useRegionMarkers.ts
@@ -6,16 +6,16 @@ import { SERVER_URL } from '@constants/server';
 import type { Region } from '../types';
 
 export const fetchRegionMarkers = async () => {
-  const stationMarkers = await fetch(`${SERVER_URL}/stations/markers/regions?regions=all`).then<
-    Region[]
-  >(async (response) => {
-    if (!response.ok) {
-      throw new Error('지역 마커를 수신을 실패했습니다.');
-    }
-    const data = await response.json();
+  const stationMarkers = await fetch(`${SERVER_URL}/stations/regions?regions=all`).then<Region[]>(
+    async (response) => {
+      if (!response.ok) {
+        throw new Error('지역 마커를 수신을 실패했습니다.');
+      }
+      const data = await response.json();
 
-    return data;
-  });
+      return data;
+    }
+  );
 
   return stationMarkers;
 };

--- a/frontend/src/components/google-maps/marker/MaxDeltaAreaMarkerContainer/hooks/useRegionMarkers.ts
+++ b/frontend/src/components/google-maps/marker/MaxDeltaAreaMarkerContainer/hooks/useRegionMarkers.ts
@@ -6,15 +6,16 @@ import { SERVER_URL } from '@constants/server';
 import type { Region } from '../types';
 
 export const fetchRegionMarkers = async () => {
-  const stationMarkers = await fetch(`${SERVER_URL}/stations/markers/regions?regions=all`)
-    .then<Region[]>(async (response) => {
-      const data = await response.json();
+  const stationMarkers = await fetch(`${SERVER_URL}/stations/markers/regions?regions=all`).then<
+    Region[]
+  >(async (response) => {
+    if (!response.ok) {
+      throw new Error('지역 마커를 수신을 실패했습니다.');
+    }
+    const data = await response.json();
 
-      return data;
-    })
-    .catch((error) => {
-      throw new Error('지역 마커를 수신을 실패했습니다.', error);
-    });
+    return data;
+  });
 
   return stationMarkers;
 };

--- a/frontend/src/mocks/handlers/station-markers/stationMarkerHandlers.ts
+++ b/frontend/src/mocks/handlers/station-markers/stationMarkerHandlers.ts
@@ -106,7 +106,7 @@ export const stationMarkerHandlers = [
       })
     );
   }),
-  rest.get(`${DEVELOP_SERVER_URL}/stations/markers/regions`, async (req, res, ctx) => {
+  rest.get(`${DEVELOP_SERVER_URL}/stations/regions`, async (req, res, ctx) => {
     const { searchParams } = req.url;
 
     const region = searchParams.get('regions');


### PR DESCRIPTION
## 📄 Summary

> 대도시 마커 렌더링이 안되는 버그가 있어 새로운 url에 맞춰서 적용합니다.

+ 에러 핸들링도 적용해서 런타임에서 터지지 않습니다.

## 🕰️ Actual Time of Completion

> 20분

## 🙋🏻 More

>


close #845

## 🚀 Storybook 

> https://storybook.carffe.in/