### PR TITLE
fix: 서버 클러스터 마커를 클릭했을 때 충전소 마커가 나오지 않고 위치만 이동하는 오류를 개선한다

### DIFF
--- a/frontend/src/constants/googleMaps.ts
+++ b/frontend/src/constants/googleMaps.ts
@@ -11,7 +11,7 @@ export const DEFAULT_CENTER = {
 
 export const DELTA_AREA_BREAKPOINTS: DeltaAreaBreakpoints = {
   small: 0.0000085,
-  medium: 0.000145,
+  medium: 0.0005,
   large: 0.137,
 };
 

--- a/frontend/src/stores/google-maps/deltaAreaStore/deltaAreaStore.test.ts
+++ b/frontend/src/stores/google-maps/deltaAreaStore/deltaAreaStore.test.ts
@@ -3,7 +3,7 @@ import { getDeltaAreaState } from './deltaAreaStore';
 describe('델타 영역 값에 따라 알맞은 상태를 반환한다.', () => {
   test.each([
     [0.137, 'max'],
-    [0.000145, 'large'],
+    [0.0005, 'large'],
     [0.136, 'large'],
     [0.0000085, 'medium'],
     [0.000144, 'medium'],


### PR DESCRIPTION
## 📄 Summary
충전소 마커에서 서버 클러스터 마커로 전환되는 영역의 너비를 3배 증가시켰습니다.

## 🕰️ Actual Time of Completion
5분

## 🙋🏻 More

>


## 🚀 Storybook 

> https://storybook.carffe.in/