### PR TITLE
fix: 데스크톱 모드에서 충전소 상세정보 보기 버튼이 항상 보여지는 문제를 수정한다

### DIFF
--- a/frontend/src/components/ui/Navigator/NavigationBar/hooks/useNavigationBar.ts
+++ b/frontend/src/components/ui/Navigator/NavigationBar/hooks/useNavigationBar.ts
@@ -46,6 +46,7 @@ export const useNavigationBar = () => {
   };
 
   return {
+    navigationBarPanel,
     toggleBasePanel,
     openLastPanel,
     closeBasePanel,

--- a/frontend/src/components/ui/StationInfoWindow/StationInfo.tsx
+++ b/frontend/src/components/ui/StationInfoWindow/StationInfo.tsx
@@ -11,6 +11,8 @@ import Button from '@common/Button';
 import FlexBox from '@common/FlexBox';
 import Text from '@common/Text';
 
+import { useNavigationBar } from '@ui/Navigator/NavigationBar/hooks/useNavigationBar';
+
 import type { StationDetails } from '@type';
 
 import PathFinding from './PathFinding';
@@ -45,6 +47,8 @@ const StationInfo = ({
     standardChargerCount,
     quickChargerCount,
   } = getChargerCountsAndAvailability(chargers);
+
+  const { navigationBarPanel } = useNavigationBar();
 
   const availabilityColor = MARKER_COLORS[isAvailable ? 'available' : 'noAvailable'];
 
@@ -102,16 +106,17 @@ const StationInfo = ({
         </Text>
       </FlexBox>
 
-      <FlexBox mt={3} justifyContent="between">
-        <Button onClick={handleOpenStationDetail} hover>
-          <FlexBox alignItems="center">
-            <Text variant="label" mb={0.75}>
-              상세 정보 보기
-            </Text>
-            <HiChevronRight />
-          </FlexBox>
-        </Button>
+      <FlexBox mt={3} justifyContent="between" mb={0.75}>
         <PathFinding address={address} latitude={latitude} longitude={longitude} />
+
+        {navigationBarPanel.lastPanel === null && (
+          <Button onClick={handleOpenStationDetail} hover>
+            <FlexBox alignItems="center">
+              <Text variant="label">상세 정보 보기</Text>
+              <HiChevronRight />
+            </FlexBox>
+          </Button>
+        )}
       </FlexBox>
     </Box>
   );


### PR DESCRIPTION
[#915]

## 📄 Summary

>

[before]
<img width="924" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/69189073/b10de9c3-9c94-49e7-b9b7-3cb94b94652b">

[after]

<img width="795" alt="image" src="https://github.com/woowacourse-teams/2023-car-ffeine/assets/69189073/858348d2-e525-41a6-a43f-d31a0a8a9243">


모바일은 동일합니다.

구두로 설명드린 내용 그대로 입니다

## 🕰️ Actual Time of Completion

> 20분

## 🙋🏻 More

>


close #915

## 🚀 Storybook 

> https://storybook.carffe.in/